### PR TITLE
fix(docker): correct sqlcmd path in sqlserver healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P XpertSphere123! -Q 'SELECT 1' || exit 1",
+          "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P XpertSphere123! -C -Q 'SELECT 1' || exit 1",
         ]
       interval: 10s
       timeout: 5s


### PR DESCRIPTION
mcr.microsoft.com/mssql/server:2022-latest ships mssql-tools18, not mssql-tools — /opt/mssql-tools/bin/sqlcmd doesn't exist in the image, so the healthcheck always failed regardless of the server's actual state. This permanently blocked monolith-api, which depends on sqlserver: condition: service_healthy. mssql-tools18 also requires -C to trust the server's self-signed certificate.