### PR TITLE
fix(recruiter-app): job offer list/detail actions and applications filtering

### DIFF
--- a/src/frontend/packages/recruiter-app/src/components/jobs/JobDialog.vue
+++ b/src/frontend/packages/recruiter-app/src/components/jobs/JobDialog.vue
@@ -77,7 +77,6 @@
                 outlined
                 type="number"
                 label="Salaire minimum"
-                suffix="€"
                 aria-label="Salaire minimum"
               />
             </div>
@@ -87,7 +86,6 @@
                 outlined
                 type="number"
                 label="Salaire maximum"
-                suffix="€"
                 aria-label="Salaire maximum"
               />
             </div>

--- a/src/frontend/packages/recruiter-app/src/pages/applications/ApplicationsPage.vue
+++ b/src/frontend/packages/recruiter-app/src/pages/applications/ApplicationsPage.vue
@@ -7,6 +7,20 @@
       </div>
     </div>
 
+    <!-- Filtre par offre d'origine -->
+    <q-banner v-if="jobOfferIdFilter" class="bg-blue-1 text-blue-10 q-mb-md">
+      <template #avatar>
+        <q-icon name="filter_alt" color="blue-10" />
+      </template>
+      <span v-if="filteredJobOfferTitle">
+        Candidatures filtrées pour l'offre « {{ filteredJobOfferTitle }} »
+      </span>
+      <span v-else>Candidatures filtrées pour une offre spécifique</span>
+      <template #action>
+        <q-btn flat label="Retirer le filtre" icon="close" @click="clearJobOfferFilter" />
+      </template>
+    </q-banner>
+
     <q-card>
       <q-card-section>
         <div class="row q-gutter-md q-mb-md">
@@ -215,10 +229,11 @@
 <script setup lang="ts">
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { ref, computed, onMounted } from 'vue';
-import { useRouter } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 import type { QTableProps } from 'quasar';
 import { date } from 'quasar';
 import { useApplicationStore } from 'src/stores/applicationStore';
+import { useJobOfferStore } from 'src/stores/jobOfferStore';
 import { useDataTable } from 'src/composables/datatable';
 import { applicationStatusConfig } from 'src/models/application';
 import type { ApplicationDto, ApplicationFilterDto } from 'src/models/application';
@@ -228,8 +243,10 @@ import ApplicationStatusUpdate from 'src/components/applications/ApplicationStat
 import ApplicationAssign from 'src/components/applications/ApplicationAssign.vue';
 import ApplicationHistory from 'src/components/applications/ApplicationHistory.vue';
 
+const route = useRoute();
 const router = useRouter();
 const applicationStore = useApplicationStore();
+const jobOfferStore = useJobOfferStore();
 const dataTable = useDataTable();
 
 const applications = computed(() => applicationStore.applications || []);
@@ -240,6 +257,11 @@ const selectedApplication = ref<ApplicationDto | null>(null);
 const showStatusDialog = ref(false);
 const showAssignDialog = ref(false);
 const showHistoryDialog = ref(false);
+
+// Filtre par offre d'origine (arrivée depuis "Voir les candidatures" sur /jobs ou /jobs/:id,
+// ou navigation directe vers /applications?jobId=<id>).
+const jobOfferIdFilter = ref<string | null>((route.query.jobId as string) ?? null);
+const filteredJobOfferTitle = ref<string | null>(null);
 
 const activeOptions = [
   { label: 'Toutes', value: null },
@@ -330,6 +352,7 @@ const onTableRequest = async (props: any) => {
     sortBy: sortBy || 'appliedAt',
     sortDesc: descending,
     organizationId: '',
+    ...(jobOfferIdFilter.value ? { jobOfferId: jobOfferIdFilter.value } : {}),
   };
 
   await applicationStore.fetchPaginatedApplications(filter);
@@ -374,7 +397,28 @@ const viewHistory = async (application: ApplicationDto) => {
   showHistoryDialog.value = true;
 };
 
+const resolveFilteredJobOfferTitle = async () => {
+  if (!jobOfferIdFilter.value) return;
+
+  try {
+    const jobOffer = await jobOfferStore.fetchJobOfferById(jobOfferIdFilter.value);
+    filteredJobOfferTitle.value = jobOffer?.title ?? null;
+  } catch {
+    // Offre supprimée entre-temps, erreur réseau… on retombe sur le libellé générique
+    // de la bannière plutôt que de bloquer l'affichage de la liste déjà filtrée côté serveur.
+    filteredJobOfferTitle.value = null;
+  }
+};
+
+const clearJobOfferFilter = () => {
+  jobOfferIdFilter.value = null;
+  filteredJobOfferTitle.value = null;
+  router.replace({ query: {} });
+  refreshData();
+};
+
 onMounted(() => {
+  void resolveFilteredJobOfferTitle();
   refreshData();
 });
 </script>

--- a/src/frontend/packages/recruiter-app/src/pages/jobs/JobOfferDetailPage.vue
+++ b/src/frontend/packages/recruiter-app/src/pages/jobs/JobOfferDetailPage.vue
@@ -276,10 +276,9 @@
               <div class="info-content q-pa-md">
                 <div class="info-group q-mb-md">
                   <div class="text-caption text-grey-7">Date de publication</div>
-                  <div v-if="!editMode" class="text-subtitle2">
+                  <div class="text-subtitle2">
                     {{ formatDate(jobOffer.publishedAt) }}
                   </div>
-                  <q-input v-else v-model="editedJob.publishedAt" type="date" dense outlined />
                 </div>
 
                 <div class="info-group">
@@ -363,6 +362,7 @@ import { useRoute, useRouter } from 'vue-router';
 import { date } from 'quasar';
 import { useJobOfferStore } from 'src/stores/jobOfferStore';
 import { useNotification } from 'src/composables/notification';
+import { useDialog } from 'src/composables/dialog';
 import { SanitizerService } from 'src/services/sanitizer';
 import type { JobOfferDto, CreateJobOfferDto } from '../../models/job';
 import { jobStatusConfig } from '../../models/job';
@@ -372,6 +372,7 @@ import { workModeLabels } from '../../enums/WorkMode';
 const route = useRoute();
 const router = useRouter();
 const notification = useNotification();
+const dialog = useDialog();
 const jobStore = useJobOfferStore();
 
 const jobOffer = ref<JobOfferDto | null>(null);
@@ -436,6 +437,14 @@ const formatSalary = (min?: number, max?: number, currency?: string) => {
 const toggleEditMode = () => {
   if (!editMode.value && jobOffer.value) {
     Object.assign(editedJob, jobOffer.value);
+    // <input type="date"> exige strictement le format YYYY-MM-DD : la valeur ISO
+    // retournée par le backend (ex. "2026-07-25T00:00:00") est silencieusement
+    // rejetée par le navigateur sans cette conversion (voir bug 3 de la spec).
+    if (editedJob.expiresAt) {
+      editedJob.expiresAt = date.formatDate(editedJob.expiresAt, 'YYYY-MM-DD');
+    } else {
+      delete editedJob.expiresAt;
+    }
   }
   editMode.value = !editMode.value;
 };
@@ -481,9 +490,18 @@ const duplicateJob = async () => {
 const confirmDelete = async () => {
   if (!jobOffer.value) return;
 
-  await jobStore.deleteJobOffer(jobOffer.value.id);
-  notification.showSuccessNotification('Offre supprimée avec succès');
-  router.push('/jobs');
+  try {
+    await dialog.confirmDelete(jobOffer.value.title, 'offre');
+  } catch {
+    // Annulé par l'utilisateur — ne rien faire
+    return;
+  }
+
+  const success = await jobStore.deleteJobOffer(jobOffer.value.id);
+  if (success) {
+    notification.showSuccessNotification('Offre supprimée avec succès');
+    router.push('/jobs');
+  }
 };
 
 onMounted(async () => {

--- a/src/frontend/packages/recruiter-app/src/pages/jobs/JobsPage.vue
+++ b/src/frontend/packages/recruiter-app/src/pages/jobs/JobsPage.vue
@@ -60,14 +60,16 @@
 import { ref, onMounted, computed } from 'vue';
 import { useRouter } from 'vue-router';
 import { useJobOfferStore } from '../../stores/jobOfferStore';
+import { useDialog } from 'src/composables/dialog';
 import JobFilters from '../../components/jobs/JobFilters.vue';
 import JobList from '../../components/jobs/JobList.vue';
 import JobDialog from '../../components/jobs/JobDialog.vue';
-import type { JobOffer, JobOfferFilter } from '../../models/job';
+import type { JobOffer, JobOfferFilter, CreateJobOfferDto } from '../../models/job';
 import { JobOfferStatus } from '../../enums';
 
 const router = useRouter();
 const jobOfferStore = useJobOfferStore();
+const dialog = useDialog();
 
 const showJobDialog = ref(false);
 const selectedJob = ref<JobOffer | null>(null);
@@ -98,19 +100,29 @@ function editJob(job: JobOffer) {
 }
 
 async function deleteJob(job: JobOffer) {
-  if (confirm(`Êtes-vous sûr de vouloir supprimer "${job.title}" ?`)) {
+  try {
+    await dialog.confirmDelete(job.title, 'offre');
     await jobOfferStore.deleteJobOffer(job.id);
+  } catch {
+    // Annulé par l'utilisateur — ne rien faire
   }
 }
 
-function duplicateJob(job: JobOffer) {
-  console.log('Duplicate job:', job.id);
-  // TODO: Implémenter la duplication
+async function duplicateJob(job: JobOffer) {
+  const duplicated: Partial<JobOffer> = {
+    ...job,
+    title: `${job.title} (Copie)`,
+  };
+  delete duplicated.id;
+
+  const result = await jobOfferStore.createJobOffer(duplicated as CreateJobOfferDto);
+  if (result) {
+    await loadJobs();
+  }
 }
 
 function viewApplications(job: JobOffer) {
-  console.log('View applications for job:', job.id);
-  // TODO: Naviguer vers les candidatures
+  router.push(`/applications?jobId=${job.id}`);
 }
 
 function handleSearch() {


### PR DESCRIPTION
## Summary
- Wires "Dupliquer"/"Voir les candidatures" actions on `/jobs` (previously inert).
- Adds delete confirmation on the job offer detail page (`/jobs/:id`).
- Fixes empty date fields in edit mode (ISO format incompatible with `<input type="date">`); publication date becomes read-only.
- Removes the hardcoded `€` suffix, which ignored the organization's actual currency.
- Wires real filtering of `ApplicationsPage.vue` by originating job offer via `?jobId=` (dismissible banner, clears URL/filter on removal).

Spec: `src/frontend/packages/recruiter-app/.claude/specifications/fix-job-offer-list-detail-actions.md`

## Test plan
- [ ] Duplicate a job offer from `/jobs` → new Draft offer titled "... (Copie)", list refreshes in place
- [ ] "Voir les candidatures" navigates to `/applications?jobId=<id>` and filters accordingly, with a dismissible banner
- [ ] Delete requires confirmation on both `/jobs` and `/jobs/:id`
- [ ] Editing a job offer shows correct dates in the date inputs; publication date is read-only
- [ ] No `€` suffix remains on salary fields in the job offer dialog