### PR TITLE
fix(recruiter-app): remove race condition in ApplicationAssign manager/evaluator lookups

### DIFF
--- a/src/frontend/packages/recruiter-app/src/components/applications/ApplicationAssign.vue
+++ b/src/frontend/packages/recruiter-app/src/components/applications/ApplicationAssign.vue
@@ -182,9 +182,9 @@ const loadManagers = async () => {
       pageSize: 100,
     };
 
-    await userStore.fetchPaginatedUsers(filter);
+    const results = await userStore.searchUsers(filter);
 
-    managerOptions.value = userStore.users.map((user) => ({
+    managerOptions.value = results.map((user) => ({
       id: user.id,
       name: user.fullName || `${user.firstName} ${user.lastName}`,
       email: user.email,
@@ -208,9 +208,9 @@ const loadEvaluators = async () => {
       pageSize: 100,
     };
 
-    await userStore.fetchPaginatedUsers(filter);
+    const results = await userStore.searchUsers(filter);
 
-    evaluatorOptions.value = userStore.users.map((user) => ({
+    evaluatorOptions.value = results.map((user) => ({
       id: user.id,
       name: user.fullName || `${user.firstName} ${user.lastName}`,
       email: user.email,

--- a/src/frontend/packages/recruiter-app/src/stores/userStore.ts
+++ b/src/frontend/packages/recruiter-app/src/stores/userStore.ts
@@ -77,6 +77,20 @@ export const useUserStore = defineStore('user', () => {
     }
   };
 
+  /**
+   * Recherche des utilisateurs sans muter l'état partagé du store (users,
+   * pagination, loading, error) ni déclencher de notification. Contrairement
+   * à `fetchPaginatedUsers`, le résultat est retourné directement à
+   * l'appelant : à utiliser lorsque plusieurs recherches concurrentes sont
+   * susceptibles d'être en vol en même temps (ex. peuplement silencieux
+   * d'options de sélection), afin qu'aucun appel ne puisse écraser le
+   * résultat d'un autre.
+   */
+  const searchUsers = async (filter: UserFilterDto = {}): Promise<UserSearchResultDto[]> => {
+    const response = await service.getPaginatedUsers(filter);
+    return response?.isSuccess ? response.data : [];
+  };
+
   const fetchUserById = async (id: string) => {
     try {
       setLoading(true);
@@ -412,6 +426,7 @@ export const useUserStore = defineStore('user', () => {
 
     clearError,
     fetchPaginatedUsers,
+    searchUsers,
     fetchUserById,
     fetchUserProfile,
     createUser,


### PR DESCRIPTION
## Summary
- `ApplicationAssign.vue` loaded managers and technical evaluators concurrently via `userStore.fetchPaginatedUsers` + reading the shared `userStore.users` state — two concurrent loads could race and mix up the two lists.
- New `userStore.searchUsers(filter)` method returns results directly, with no shared-state mutation and no notification side effects, used by both lookups instead.
- `fetchPaginatedUsers` and its other callers (`CandidatesPage.vue`, `UsersPage.vue`) are untouched.

Spec: `src/frontend/packages/recruiter-app/.claude/specifications/fix-application-assign-race-condition.md`

## Test plan
- [ ] Opening the assign dialog no longer mixes up Manager/Évaluateur technique options under slow network conditions
- [ ] No spurious success notification when opening the assign dialog
- [ ] `CandidatesPage.vue`/`UsersPage.vue` pagination unaffected