### PR TITLE
fix(api): scope role detail/update endpoints and wire role users dialog

### DIFF
--- a/src/backend/XpertSphere.MonolithApi.Tests/Services/RoleServiceTests.cs
+++ b/src/backend/XpertSphere.MonolithApi.Tests/Services/RoleServiceTests.cs
@@ -490,6 +490,244 @@ public class RoleServiceTests : IDisposable
         roleDto.UsersCount.Should().Be(0);
     }
 
+    [Fact]
+    public async Task GetRoleByIdAsync_AsOrganizationAdmin_ShouldScopeUsersCountToOrganization()
+    {
+        // Arrange
+        var organizationAId = Guid.NewGuid();
+        var organizationBId = Guid.NewGuid();
+
+        var role = new Role
+        {
+            Id = Guid.NewGuid(),
+            Name = "Organization.Recruiter",
+            DisplayName = "Recruiter",
+            IsActive = true
+        };
+
+        var userInOrgA = new User
+        {
+            Id = Guid.NewGuid(),
+            Email = "recruiter-detail-a@example.com",
+            FirstName = "Recruiter",
+            LastName = "OrgA",
+            IsActive = true,
+            OrganizationId = organizationAId
+        };
+
+        var userInOrgB = new User
+        {
+            Id = Guid.NewGuid(),
+            Email = "recruiter-detail-b@example.com",
+            FirstName = "Recruiter",
+            LastName = "OrgB",
+            IsActive = true,
+            OrganizationId = organizationBId
+        };
+
+        _context.Roles.Add(role);
+        _context.Users.AddRange(userInOrgA, userInOrgB);
+        _context.UserRoles.AddRange(
+            new UserRole { Id = Guid.NewGuid(), UserId = userInOrgA.Id, RoleId = role.Id, IsActive = true },
+            new UserRole { Id = Guid.NewGuid(), UserId = userInOrgB.Id, RoleId = role.Id, IsActive = true }
+        );
+        await _context.SaveChangesAsync();
+
+        _mockCurrentUserService.Setup(x => x.User)
+            .Returns(CreateClaimsPrincipal(Roles.OrganizationAdmin.Name));
+        _mockCurrentUserService.Setup(x => x.OrganizationId).Returns(organizationAId);
+
+        var mapper = AutoMapperHelper.CreateMapper();
+        var roleService = CreateRoleService(mapper);
+
+        // Act
+        var result = await roleService.GetRoleByIdAsync(role.Id);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Data!.UsersCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetRoleByIdAsync_AsPlatformAdmin_ShouldCountAllOrganizations()
+    {
+        // Arrange
+        var organizationAId = Guid.NewGuid();
+        var organizationBId = Guid.NewGuid();
+
+        var role = new Role
+        {
+            Id = Guid.NewGuid(),
+            Name = "Organization.Recruiter",
+            DisplayName = "Recruiter",
+            IsActive = true
+        };
+
+        var userInOrgA = new User
+        {
+            Id = Guid.NewGuid(),
+            Email = "recruiter-detail-a2@example.com",
+            FirstName = "Recruiter",
+            LastName = "OrgA",
+            IsActive = true,
+            OrganizationId = organizationAId
+        };
+
+        var userInOrgB = new User
+        {
+            Id = Guid.NewGuid(),
+            Email = "recruiter-detail-b2@example.com",
+            FirstName = "Recruiter",
+            LastName = "OrgB",
+            IsActive = true,
+            OrganizationId = organizationBId
+        };
+
+        _context.Roles.Add(role);
+        _context.Users.AddRange(userInOrgA, userInOrgB);
+        _context.UserRoles.AddRange(
+            new UserRole { Id = Guid.NewGuid(), UserId = userInOrgA.Id, RoleId = role.Id, IsActive = true },
+            new UserRole { Id = Guid.NewGuid(), UserId = userInOrgB.Id, RoleId = role.Id, IsActive = true }
+        );
+        await _context.SaveChangesAsync();
+
+        _mockCurrentUserService.Setup(x => x.User)
+            .Returns(CreateClaimsPrincipal(Roles.PlatformAdmin.Name));
+
+        var mapper = AutoMapperHelper.CreateMapper();
+        var roleService = CreateRoleService(mapper);
+
+        // Act
+        var result = await roleService.GetRoleByIdAsync(role.Id);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Data!.UsersCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetRoleByNameAsync_AsOrganizationAdmin_ShouldScopeUsersCountToOrganization()
+    {
+        // Arrange
+        var organizationAId = Guid.NewGuid();
+        var organizationBId = Guid.NewGuid();
+
+        var role = new Role
+        {
+            Id = Guid.NewGuid(),
+            Name = "Organization.RecruiterByName",
+            DisplayName = "Recruiter",
+            IsActive = true
+        };
+
+        var userInOrgA = new User
+        {
+            Id = Guid.NewGuid(),
+            Email = "recruiter-detail-name-a@example.com",
+            FirstName = "Recruiter",
+            LastName = "OrgA",
+            IsActive = true,
+            OrganizationId = organizationAId
+        };
+
+        var userInOrgB = new User
+        {
+            Id = Guid.NewGuid(),
+            Email = "recruiter-detail-name-b@example.com",
+            FirstName = "Recruiter",
+            LastName = "OrgB",
+            IsActive = true,
+            OrganizationId = organizationBId
+        };
+
+        _context.Roles.Add(role);
+        _context.Users.AddRange(userInOrgA, userInOrgB);
+        _context.UserRoles.AddRange(
+            new UserRole { Id = Guid.NewGuid(), UserId = userInOrgA.Id, RoleId = role.Id, IsActive = true },
+            new UserRole { Id = Guid.NewGuid(), UserId = userInOrgB.Id, RoleId = role.Id, IsActive = true }
+        );
+        await _context.SaveChangesAsync();
+
+        _mockCurrentUserService.Setup(x => x.User)
+            .Returns(CreateClaimsPrincipal(Roles.OrganizationAdmin.Name));
+        _mockCurrentUserService.Setup(x => x.OrganizationId).Returns(organizationAId);
+
+        var mapper = AutoMapperHelper.CreateMapper();
+        var roleService = CreateRoleService(mapper);
+
+        // Act
+        var result = await roleService.GetRoleByNameAsync("Organization.RecruiterByName");
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Data!.UsersCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task UpdateRoleAsync_WithExistingActiveUsers_ShouldReturnRealUsersCount()
+    {
+        // Arrange
+        var roleId = Guid.NewGuid();
+        var role = new Role
+        {
+            Id = roleId,
+            Name = "RoleWithUsers",
+            DisplayName = "Role With Users",
+            IsActive = true
+        };
+
+        var user1 = new User
+        {
+            Id = Guid.NewGuid(),
+            Email = "update-role-user-1@example.com",
+            FirstName = "User",
+            LastName = "One",
+            IsActive = true
+        };
+
+        var user2 = new User
+        {
+            Id = Guid.NewGuid(),
+            Email = "update-role-user-2@example.com",
+            FirstName = "User",
+            LastName = "Two",
+            IsActive = true
+        };
+
+        _context.Roles.Add(role);
+        _context.Users.AddRange(user1, user2);
+        _context.UserRoles.AddRange(
+            new UserRole { Id = Guid.NewGuid(), UserId = user1.Id, RoleId = roleId, IsActive = true },
+            new UserRole { Id = Guid.NewGuid(), UserId = user2.Id, RoleId = roleId, IsActive = true }
+        );
+        await _context.SaveChangesAsync();
+
+        var updateRoleDto = new UpdateRoleDto
+        {
+            DisplayName = "Role With Users Updated",
+            IsActive = true
+        };
+
+        _mockUpdateRoleValidator.Setup(x => x.ValidateAsync(updateRoleDto, default))
+            .ReturnsAsync(new FluentValidation.Results.ValidationResult());
+
+        // Endpoint réservé à un PlatformSuperAdmin en pratique (policy `RequirePlatformSuperAdminRole`),
+        // donc pas de scoping applicable ; comportement identique quel que soit le rôle de l'appelant.
+        _mockCurrentUserService.Setup(x => x.User)
+            .Returns(CreateClaimsPrincipal(Roles.PlatformSuperAdmin.Name));
+
+        var mapper = AutoMapperHelper.CreateMapper();
+        var roleService = CreateRoleService(mapper);
+
+        // Act
+        var result = await roleService.UpdateRoleAsync(roleId, updateRoleDto);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Data!.UsersCount.Should().Be(2);
+        result.Data.DisplayName.Should().Be("Role With Users Updated");
+    }
+
     private static ClaimsPrincipal CreateClaimsPrincipal(string roleName)
     {
         var identity = new ClaimsIdentity(

--- a/src/backend/XpertSphere.MonolithApi/Controllers/UserRolesController.cs
+++ b/src/backend/XpertSphere.MonolithApi/Controllers/UserRolesController.cs
@@ -34,7 +34,7 @@ public class UserRolesController : ControllerBase
     /// Get all users for a specific role
     /// </summary>
     [HttpGet("role/{roleId:guid}")]
-    [Authorize(Policy = "RequirePlatformRole")]
+    [Authorize(Policy = "RequirePlatformOrOrganizationAdminRole")]
     public async Task<ActionResult<IEnumerable<UserRoleDto>>> GetRoleUsers(Guid roleId)
     {
         var result = await _userRoleService.GetRoleUsersAsync(roleId);

--- a/src/backend/XpertSphere.MonolithApi/Extensions/SecurityExtensions.cs
+++ b/src/backend/XpertSphere.MonolithApi/Extensions/SecurityExtensions.cs
@@ -486,6 +486,12 @@ public static class SecurityExtensions
             options.AddPolicy("RequirePlatformRole", policy =>
                 policy.RequireRole(Roles.PlatformRoles));
 
+            options.AddPolicy("RequirePlatformOrOrganizationAdminRole", policy =>
+                policy.RequireRole(
+                    Roles.PlatformSuperAdmin.Name,
+                    Roles.PlatformAdmin.Name,
+                    Roles.OrganizationAdmin.Name));
+
             options.AddPolicy("RequirePlatformSuperAdminRole", policy =>
                 policy.RequireRole(Roles.PlatformSuperAdmin.Name));
 

--- a/src/backend/XpertSphere.MonolithApi/Services/RoleService.cs
+++ b/src/backend/XpertSphere.MonolithApi/Services/RoleService.cs
@@ -105,9 +105,7 @@ public class RoleService : IRoleService
     {
         try
         {
-            var role = await _context.Roles
-                .Include(r => r.UserRoles)
-                .Include(r => r.RolePermissions)
+            var role = await BuildScopedRoleDetailQuery()
                 .Where(r => r.Id == id)
                 .FirstOrDefaultAsync();
 
@@ -130,9 +128,7 @@ public class RoleService : IRoleService
     {
         try
         {
-            var role = await _context.Roles
-                .Include(r => r.UserRoles)
-                .Include(r => r.RolePermissions)
+            var role = await BuildScopedRoleDetailQuery()
                 .Where(r => r.Name == name)
                 .FirstOrDefaultAsync();
 
@@ -213,7 +209,10 @@ public class RoleService : IRoleService
 
             _logger.LogInformation("Updated role with ID {RoleId}", id);
 
-            var roleDto = _mapper.Map<RoleDto>(role);
+            var reloadedRole = await BuildScopedRoleDetailQuery()
+                .Where(r => r.Id == id)
+                .FirstOrDefaultAsync();
+            var roleDto = _mapper.Map<RoleDto>(reloadedRole ?? role);
             return ServiceResult<RoleDto>.Success(roleDto, "Rôle mis à jour avec succès");
         }
         catch (Exception ex)
@@ -354,6 +353,31 @@ public class RoleService : IRoleService
             _logger.LogError(ex, "Error checking if role can be deleted with ID {RoleId}", id);
             return ServiceResult<bool>.InternalError("Une erreur est survenue lors de la vérification de la suppressibilité du rôle");
         }
+    }
+
+    private IQueryable<Role> BuildScopedRoleDetailQuery()
+    {
+        var isAuthenticated = _currentUserService.User?.Identity?.IsAuthenticated == true;
+        var isPlatformUser = isAuthenticated &&
+            (_currentUserService.User!.IsInRole(Roles.PlatformSuperAdmin.Name) ||
+             _currentUserService.User.IsInRole(Roles.PlatformAdmin.Name));
+        var isOrgAdmin = isAuthenticated && _currentUserService.User!.IsInRole(Roles.OrganizationAdmin.Name);
+        var isManager = isAuthenticated && _currentUserService.User!.IsInRole(Roles.Manager.Name);
+
+        var shouldScopeUserRolesToOrganization =
+            (isOrgAdmin || isManager) && !isPlatformUser && _currentUserService.OrganizationId.HasValue;
+
+        return shouldScopeUserRolesToOrganization
+            ? _context.Roles
+                .AsNoTracking()
+                .Include(r => r.UserRoles.Where(ur => ur.User.OrganizationId == _currentUserService.OrganizationId!.Value))
+                .ThenInclude(ur => ur.User)
+                .Include(r => r.RolePermissions)
+            : _context.Roles
+                .AsNoTracking()
+                .Include(r => r.UserRoles)
+                .ThenInclude(ur => ur.User)
+                .Include(r => r.RolePermissions);
     }
 
     private IQueryable<Role> BuildRoleQuery(RoleFilterDto filter)

--- a/src/frontend/packages/recruiter-app/src/pages/admin/RolesPage.vue
+++ b/src/frontend/packages/recruiter-app/src/pages/admin/RolesPage.vue
@@ -76,6 +76,13 @@
                       <q-item-section>Modifier</q-item-section>
                     </q-item>
 
+                    <q-item v-close-popup clickable @click="viewRoleUsers(props.row)">
+                      <q-item-section avatar>
+                        <q-icon name="group" color="primary" />
+                      </q-item-section>
+                      <q-item-section>Voir les utilisateurs</q-item-section>
+                    </q-item>
+
                     <q-item v-close-popup clickable @click="confirmToggleStatus(props.row)">
                       <q-item-section avatar>
                         <q-icon
@@ -325,7 +332,12 @@ const columns: Ref<QTableColumn<any>[]> = ref([
 ]);
 
 const userRoleColumns: Ref<QTableColumn<any>[]> = ref([
-  { name: 'userName', field: 'userName', label: 'Utilisateur', ...dataTable.defaultConfig.value },
+  {
+    name: 'userFullName',
+    field: 'userFullName',
+    label: 'Utilisateur',
+    ...dataTable.defaultConfig.value,
+  },
   { name: 'userEmail', field: 'userEmail', label: 'Email', ...dataTable.defaultConfig.value },
   {
     name: 'isActive',
@@ -418,6 +430,12 @@ const editRole = (role: RoleDto) => {
     isActive: role.isActive,
   });
   showCreateDialog.value = true;
+};
+
+const viewRoleUsers = async (role: RoleDto) => {
+  selectedRole.value = role;
+  showUserRolesDialog.value = true;
+  await userRoleStore.fetchRoleUsers(role.id);
 };
 
 const saveRole = async () => {


### PR DESCRIPTION
## Summary
- Extends the organization-scoping fix already applied to `GetAllPaginatedRolesAsync`/`GetRoleUsersAsync` to `RoleService.GetRoleByIdAsync`, `GetRoleByNameAsync`, and `UpdateRoleAsync` (new shared `BuildScopedRoleDetailQuery` helper), so `Organization.Admin` sees the real user count for their own organization instead of a cross-organization total.
- New `RequirePlatformOrOrganizationAdminRole` policy, lifting a 403 previously blocking `Organization.Admin` on `GET /api/UserRoles/role/{roleId}`.
- `recruiter-app`: wires the previously-dead "Voir les utilisateurs" menu action on `RolesPage.vue` to the existing dialog, and fixes an incorrect column field (`userName` → `userFullName`, `UserRoleDto` has no `userName`).

Spec: `src/backend/XpertSphere.MonolithApi/.claude/specifications/role-detail-scope-fix-users-dialog-wiring.md`

## Test plan
- [x] 180/180 backend tests pass, including 4 new tests covering scoping on `GetRoleByIdAsync`/`GetRoleByNameAsync`/`UpdateRoleAsync`
- [x] `npm run lint` / `vue-tsc --noEmit` clean on `recruiter-app` (one pre-existing, unrelated error confirmed on `develop`)
- [ ] Manual: `Organization.Admin` can open "Voir les utilisateurs" from `/admin/roles` and see the correctly-scoped user list; `PlatformAdmin` behavior unchanged

## Note
Found (not fixed, out of scope): `RoleDto.PermissionsCount` on the paginated roles list appears to always be 0 in production — `BuildRoleQuery` never `.Include()`s `RolePermissions`, unlike the new detail helper. Flagged for a future ticket.