### PR TITLE
feat(api): localize Identity error messages and align password rules with backend policy

### DIFF
--- a/src/backend/XpertSphere.MonolithApi.Tests/Integration/CustomWebApplicationFactory.cs
+++ b/src/backend/XpertSphere.MonolithApi.Tests/Integration/CustomWebApplicationFactory.cs
@@ -1,0 +1,101 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using XpertSphere.MonolithApi.Data;
+
+namespace XpertSphere.MonolithApi.Tests.Integration;
+
+/// <summary>
+/// Boots the real ASP.NET Core pipeline (Program.cs) end-to-end - real Identity, real
+/// FrenchIdentityErrorDescriber, real DataAnnotations model binding/validation, real
+/// authentication/authorization - against an EF Core InMemory database instead of SQL Server, so
+/// that the HTTP-level verification required by
+/// .claude/specifications/localize-identity-error-messages.md (critères d'acceptation 3, 4, 5, 9)
+/// does not depend on a running SQL Server instance.
+///
+/// The "Development" environment is used deliberately (not a dedicated "Testing" environment):
+/// KeyVaultExtensions.AddKeyVaultConfiguration and the Application Insights wiring in Program.cs
+/// both throw/require real Azure configuration for any environment where
+/// IWebHostEnvironment.IsDevelopment() is false. Using "Development" here is the smallest way to
+/// avoid touching that unrelated startup code while still exercising the real pipeline; it does
+/// mean the full demo dataset (SeedDemoDataAsync) also runs once per factory instance, which is a
+/// few extra seconds, not a correctness concern (see DatabaseExtensions.DemoData.cs - no raw SQL,
+/// no transactions, no blob storage calls, confirmed compatible with the InMemory provider).
+/// </summary>
+public class CustomWebApplicationFactory : WebApplicationFactory<Program>
+{
+    // Shared by every DbContext instance resolved from this factory's service provider, so that
+    // data seeded during startup (PlatformSuperAdmin, roles, etc.) is visible to every request
+    // handled by the same factory/client.
+    private readonly string _databaseName = $"integration-tests-{Guid.NewGuid()}";
+
+    /// <summary>
+    /// Credentials of the PlatformSuperAdmin account seeded by SeedPlatformSuperAdminAsync for
+    /// this factory instance (see Admin:Email / Admin:Password below) - usable by integration
+    /// tests that need an authenticated organization/platform-scoped call (e.g. criterion 5,
+    /// admin-reset-password).
+    /// </summary>
+    public const string SeededAdminEmail = "integration-test-admin@xpertsphere.local";
+
+    public const string SeededAdminPassword = "IntegrationTestAdmin1!";
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Development");
+
+        builder.ConfigureAppConfiguration((_, config) =>
+        {
+            // Values that a real local run would source from a .env file (via DotNetEnv) or from
+            // Azure Key Vault (Staging/Production) - none of which exist in this test
+            // environment. Every key below is read via IConfiguration["..."] or
+            // Environment.GetEnvironmentVariable("...") somewhere in Program.cs/SecurityExtensions
+            // /DatabaseExtensions and throws InvalidOperationException at startup if missing.
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Jwt:Key"] = "integration-tests-signing-key-at-least-256-bits-long-0123456789",
+                ["Admin:Email"] = SeededAdminEmail,
+                ["Admin:Password"] = SeededAdminPassword,
+                // SeedPlatformSuperAdminAsync looks up the seeded organization by comparing
+                // Organization.Name to the hardcoded Utils.Constants.XPERTSPHERE ("XPERTSPHERE",
+                // all caps), while appsettings.json's Seeding:Organization:Name is "XpertSphere"
+                // (mixed case). This comparison relies on SQL Server's default case-insensitive
+                // collation in real deployments; the EF Core InMemory provider used by this
+                // harness performs ordinal (case-sensitive) comparisons, so the two would never
+                // match without this override. Not a production bug - a provider-behavior
+                // difference specific to this test harness - so fixed here at the configuration
+                // level rather than in DatabaseExtensions.cs.
+                ["Seeding:Organization:Name"] = "XPERTSPHERE"
+            });
+        });
+
+        builder.ConfigureServices(services =>
+        {
+            // Replace the SQL Server DbContextOptions registered by AddDatabase(...) in
+            // Program.cs with the EF Core InMemory provider - the only change needed to run this
+            // application without a real SQL Server instance. AddDbContext appends an
+            // IDbContextOptionsConfiguration<XpertSphereDbContext> descriptor per call rather than
+            // replacing the previous one, so both the SQL Server and InMemory configurations would
+            // otherwise be applied to the same options ("Only a single database provider can be
+            // registered" at startup) - remove every existing registration for this context before
+            // adding ours.
+            services.RemoveAll<DbContextOptions<XpertSphereDbContext>>();
+            services.RemoveAll(typeof(IDbContextOptionsConfiguration<XpertSphereDbContext>));
+
+            services.AddDbContext<XpertSphereDbContext>(options =>
+            {
+                options.UseInMemoryDatabase(_databaseName);
+                // AuthenticationService wraps several operations (e.g. RegisterCandidateAsync) in
+                // an explicit Database.BeginTransactionAsync(); the InMemory provider does not
+                // support real transactions and otherwise logs/throws a
+                // TransactionIgnoredWarning - silence it here since it is expected and harmless
+                // for this test harness.
+                options.ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning));
+            });
+        });
+    }
+}

--- a/src/backend/XpertSphere.MonolithApi.Tests/Integration/CustomWebApplicationFactory.cs
+++ b/src/backend/XpertSphere.MonolithApi.Tests/Integration/CustomWebApplicationFactory.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -6,7 +7,10 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 using XpertSphere.MonolithApi.Data;
+using XpertSphere.MonolithApi.Models;
+using XpertSphere.MonolithApi.Utils;
 
 namespace XpertSphere.MonolithApi.Tests.Integration;
 
@@ -59,17 +63,15 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
             {
                 ["Jwt:Key"] = "integration-tests-signing-key-at-least-256-bits-long-0123456789",
                 ["Admin:Email"] = SeededAdminEmail,
-                ["Admin:Password"] = SeededAdminPassword,
-                // SeedPlatformSuperAdminAsync looks up the seeded organization by comparing
-                // Organization.Name to the hardcoded Utils.Constants.XPERTSPHERE ("XPERTSPHERE",
-                // all caps), while appsettings.json's Seeding:Organization:Name is "XpertSphere"
-                // (mixed case). This comparison relies on SQL Server's default case-insensitive
-                // collation in real deployments; the EF Core InMemory provider used by this
-                // harness performs ordinal (case-sensitive) comparisons, so the two would never
-                // match without this override. Not a production bug - a provider-behavior
-                // difference specific to this test harness - so fixed here at the configuration
-                // level rather than in DatabaseExtensions.cs.
-                ["Seeding:Organization:Name"] = "XPERTSPHERE"
+                ["Admin:Password"] = SeededAdminPassword
+                // Seeding:Organization:Name is deliberately left at its appsettings.json default
+                // ("XpertSphere") rather than overridden here, so that this harness stays
+                // production-faithful on a security-relevant value: SecurityExtensions.cs policies
+                // (CanCreateUsers, OrganizationIsolation, CanResetPasswords, ...) compare an
+                // "OrganizationName" claim against the literal "XpertSphere" with ordinal,
+                // case-sensitive C# `==`. See EnsureSeededAdminExistsAsync below for why
+                // SeedPlatformSuperAdminAsync itself still needs a helping hand under this
+                // specific combination of provider and organization name casing.
             });
         });
 
@@ -97,5 +99,76 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
                 options.ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning));
             });
         });
+    }
+
+    protected override IHost CreateHost(IHostBuilder builder)
+    {
+        var host = base.CreateHost(builder);
+
+        // DatabaseExtensions.SeedPlatformSuperAdminAsync (run as part of the real startup
+        // sequence above) looks up the just-seeded XpertSphere organization via
+        // context.Organizations.FirstOrDefaultAsync(o => o.Name == Constants.XPERTSPHERE)
+        // ("XPERTSPHERE", all caps) while the organization's actual Name is "XpertSphere" (mixed
+        // case, from Seeding:Organization:Name - deliberately left at its production value, see
+        // ConfigureWebHost above). That comparison matches under SQL Server's default
+        // case-insensitive collation in real deployments, but never matches under the EF Core
+        // InMemory provider's ordinal comparison, so the built-in seeding silently skips creating
+        // the PlatformSuperAdmin account here. Rather than change the organization's name (which
+        // would make this harness diverge from production on a claim value used by
+        // ordinal-comparison authorization policies in SecurityExtensions.cs), seed the same
+        // account directly against the already-persisted, production-faithful "XpertSphere"
+        // organization.
+        using var scope = host.Services.CreateScope();
+        EnsureSeededAdminExistsAsync(scope.ServiceProvider).GetAwaiter().GetResult();
+
+        return host;
+    }
+
+    private static async Task EnsureSeededAdminExistsAsync(IServiceProvider services)
+    {
+        var userManager = services.GetRequiredService<UserManager<User>>();
+        if (await userManager.FindByEmailAsync(SeededAdminEmail) != null)
+        {
+            // Already created by the real startup seeding (e.g. organization name casing
+            // happened to match) - nothing to do.
+            return;
+        }
+
+        var context = services.GetRequiredService<XpertSphereDbContext>();
+        var organization = await context.Organizations.FirstAsync(o => o.Name == "XpertSphere");
+        var superAdminRole = await context.Roles.FirstAsync(r => r.Name == Roles.PlatformSuperAdmin.Name);
+
+        var admin = new User
+        {
+            Id = Guid.NewGuid(),
+            FirstName = "Super",
+            LastName = "Admin",
+            Email = SeededAdminEmail,
+            UserName = SeededAdminEmail,
+            EmailConfirmed = true,
+            OrganizationId = organization.Id,
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            ConsentGivenAt = DateTime.UtcNow
+        };
+
+        var createResult = await userManager.CreateAsync(admin, SeededAdminPassword);
+        if (!createResult.Succeeded)
+        {
+            throw new InvalidOperationException(
+                "Failed to seed the integration test PlatformSuperAdmin account: " +
+                string.Join(", ", createResult.Errors.Select(e => e.Description)));
+        }
+
+        context.UserRoles.Add(new UserRole
+        {
+            Id = Guid.NewGuid(),
+            UserId = admin.Id,
+            RoleId = superAdminRole.Id,
+            IsActive = true,
+            AssignedAt = DateTime.UtcNow
+        });
+
+        await context.SaveChangesAsync();
     }
 }

--- a/src/backend/XpertSphere.MonolithApi.Tests/Integration/IdentityErrorLocalizationIntegrationTests.cs
+++ b/src/backend/XpertSphere.MonolithApi.Tests/Integration/IdentityErrorLocalizationIntegrationTests.cs
@@ -1,0 +1,183 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Xunit.Abstractions;
+
+namespace XpertSphere.MonolithApi.Tests.Integration;
+
+/// <summary>
+/// End-to-end (real HTTP, real ASP.NET Core pipeline, real Identity, no mocked
+/// UserManager/DbContext) verification of critères d'acceptation 3, 4, 5 and 9 of
+/// .claude/specifications/localize-identity-error-messages.md: closes the gap flagged by the
+/// validator on PR #132, where these criteria required a non-mocked HTTP-level check that native
+/// ASP.NET Core Identity error messages and DataAnnotations validation messages are returned in
+/// French in the HTTP response body.
+///
+/// Uses <see cref="CustomWebApplicationFactory"/> (WebApplicationFactory&lt;Program&gt; + EF Core
+/// InMemory provider) rather than a unit test with a mocked UserManager, precisely because a
+/// mocked UserManager never goes through the real FrenchIdentityErrorDescriber nor through the
+/// real ASP.NET Core model-binding/validation pipeline that produces ValidationProblemDetails.
+/// </summary>
+[Trait("Category", "Integration")]
+public class IdentityErrorLocalizationIntegrationTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly CustomWebApplicationFactory _factory;
+    private readonly ITestOutputHelper _output;
+
+    public IdentityErrorLocalizationIntegrationTests(CustomWebApplicationFactory factory, ITestOutputHelper output)
+    {
+        _factory = factory;
+        _output = output;
+    }
+
+    /// <summary>
+    /// Critère d'acceptation 4 : lien de confirmation d'email invalide/expiré
+    /// (<c>ConfirmEmailAsync</c>) -&gt; message entièrement français, plus de "Invalid token" en
+    /// anglais concaténé. Uses the PlatformSuperAdmin account seeded by
+    /// SeedPlatformSuperAdminAsync (see CustomWebApplicationFactory) - its EmailConfirmed state is
+    /// irrelevant here since UserManager.ConfirmEmailAsync fails on token verification before
+    /// ever looking at the current confirmation state.
+    /// </summary>
+    [Fact]
+    public async Task ConfirmEmail_WithInvalidToken_ReturnsFrenchMessage_NotEnglish()
+    {
+        using var client = _factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/Auth/confirm-email", new
+        {
+            Email = CustomWebApplicationFactory.SeededAdminEmail,
+            Token = "this-is-not-a-valid-token"
+        });
+
+        var body = await response.Content.ReadAsStringAsync();
+        _output.WriteLine($"Status: {(int)response.StatusCode}");
+        _output.WriteLine($"Body: {body}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        body.Should().Contain("Jeton invalide");
+        body.Should().NotContain("Invalid token");
+    }
+
+    /// <summary>
+    /// Critère d'acceptation 9 (volet DataAnnotations) : <c>POST /api/Auth/register/candidate</c>
+    /// avec <c>Email</c> manquant renvoie un message entièrement français dans le corps de la
+    /// réponse HTTP (<c>ValidationProblemDetails</c> produit par le ModelState binding
+    /// automatique d'<c>[ApiController]</c>, pas par le contrôleur ni par
+    /// AuthenticationService).
+    /// </summary>
+    [Fact]
+    public async Task RegisterCandidate_WithMissingEmail_ReturnsFrenchValidationProblemDetails()
+    {
+        using var client = _factory.CreateClient();
+
+        using var form = new MultipartFormDataContent
+        {
+            { new StringContent("Abcdefgh1!"), "Password" },
+            { new StringContent("Abcdefgh1!"), "ConfirmPassword" },
+            { new StringContent("Jean"), "FirstName" },
+            { new StringContent("Dupont"), "LastName" },
+            { new StringContent("true"), "AcceptTerms" },
+            { new StringContent("true"), "AcceptPrivacyPolicy" }
+        };
+
+        var response = await client.PostAsync("/api/Auth/register/candidate", form);
+
+        var body = await response.Content.ReadAsStringAsync();
+        _output.WriteLine($"Status: {(int)response.StatusCode}");
+        _output.WriteLine($"Body: {body}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        body.Should().Contain("obligatoire");
+
+        using var problemDetails = JsonDocument.Parse(body);
+        var emailErrors = problemDetails.RootElement.GetProperty("errors").GetProperty("Email");
+        var emailErrorMessages = emailErrors.EnumerateArray().Select(e => e.GetString()).ToList();
+        emailErrorMessages.Should().ContainSingle(m => m != null && m.Contains("obligatoire"));
+    }
+
+    /// <summary>
+    /// Critère d'acceptation 3 : <c>POST /api/Auth/register/candidate</c> avec un mot de passe
+    /// respectant la longueur (8 caractères, valide dans les deux environnements) mais sans
+    /// caractère non-alphanumérique -&gt; message entièrement français
+    /// (<c>PasswordRequiresNonAlphanumeric</c> via <see cref="Utils.FrenchIdentityErrorDescriber"/>),
+    /// sans aucun fragment anglais résiduel.
+    /// </summary>
+    [Fact]
+    public async Task RegisterCandidate_WithNonAlphanumericMissingPassword_ReturnsFrenchMessage_NotEnglish()
+    {
+        using var client = _factory.CreateClient();
+
+        var uniqueEmail = $"candidate-{Guid.NewGuid():N}@example.com";
+        using var form = new MultipartFormDataContent
+        {
+            { new StringContent(uniqueEmail), "Email" },
+            { new StringContent("Abcdefgh1"), "Password" },
+            { new StringContent("Abcdefgh1"), "ConfirmPassword" },
+            { new StringContent("Jean"), "FirstName" },
+            { new StringContent("Dupont"), "LastName" },
+            { new StringContent("true"), "AcceptTerms" },
+            { new StringContent("true"), "AcceptPrivacyPolicy" }
+        };
+
+        var response = await client.PostAsync("/api/Auth/register/candidate", form);
+
+        var body = await response.Content.ReadAsStringAsync();
+        _output.WriteLine($"Status: {(int)response.StatusCode}");
+        _output.WriteLine($"Body: {body}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        body.Should().Contain("caract");
+        (body.Contains("spécial") || body.Contains("sp\\u00E9cial")).Should().BeTrue();
+        body.Should().NotContain("alphanumeric");
+        body.Should().NotContain("Passwords must");
+    }
+
+    /// <summary>
+    /// Critère d'acceptation 5 : réinitialisation de mot de passe admin
+    /// (<c>AdminResetPasswordAsync</c>, flux <c>recruiter-app/UsersPage.vue</c>) avec un mot de
+    /// passe ne respectant pas la complexité (règle client ne vérifiant que la longueur) ->
+    /// message entièrement français. Logs in as the seeded PlatformSuperAdmin (real JWT, real
+    /// CanResetPasswords policy evaluation) then targets its own account to avoid any
+    /// cross-organization authorization branch.
+    /// </summary>
+    [Fact]
+    public async Task AdminResetPassword_WithNonAlphanumericMissingPassword_ReturnsFrenchMessage_NotEnglish()
+    {
+        using var client = _factory.CreateClient();
+
+        var loginResponse = await client.PostAsJsonAsync("/api/Auth/login", new
+        {
+            Email = CustomWebApplicationFactory.SeededAdminEmail,
+            Password = CustomWebApplicationFactory.SeededAdminPassword
+        });
+
+        var loginBody = await loginResponse.Content.ReadAsStringAsync();
+        _output.WriteLine($"Login status: {(int)loginResponse.StatusCode}");
+        _output.WriteLine($"Login body: {loginBody}");
+        loginResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var loginDocument = JsonDocument.Parse(loginBody);
+        var accessToken = loginDocument.RootElement.GetProperty("data").GetProperty("accessToken").GetString();
+        accessToken.Should().NotBeNullOrEmpty();
+
+        client.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", accessToken);
+
+        var resetResponse = await client.PostAsJsonAsync("/api/Auth/admin-reset-password", new
+        {
+            Email = CustomWebApplicationFactory.SeededAdminEmail,
+            NewPassword = "Abcdefg1",
+            ConfirmPassword = "Abcdefg1"
+        });
+
+        var resetBody = await resetResponse.Content.ReadAsStringAsync();
+        _output.WriteLine($"Reset status: {(int)resetResponse.StatusCode}");
+        _output.WriteLine($"Reset body: {resetBody}");
+
+        resetResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        resetBody.Should().Contain("caract");
+        resetBody.Should().NotContain("alphanumeric");
+        resetBody.Should().NotContain("Passwords must");
+    }
+}

--- a/src/backend/XpertSphere.MonolithApi.Tests/Services/AuthenticationServiceTests.cs
+++ b/src/backend/XpertSphere.MonolithApi.Tests/Services/AuthenticationServiceTests.cs
@@ -356,7 +356,7 @@ public class AuthenticationServiceTests : IDisposable
 
         var identityErrors = new List<IdentityError>
         {
-            new() { Code = "InvalidToken", Description = "Invalid token" }
+            new() { Code = "InvalidToken", Description = "Jeton invalide." }
         };
 
         _mockUserManager.Setup(x => x.ConfirmEmailAsync(user, confirmEmailDto.Token))
@@ -370,7 +370,7 @@ public class AuthenticationServiceTests : IDisposable
 
         // Assert
         result.IsSuccess.Should().BeFalse();
-        result.Errors.Should().Contain("Échec de la confirmation de l'email : Invalid token");
+        result.Errors.Should().Contain("Échec de la confirmation de l'email : Jeton invalide.");
     }
 
     [Fact]

--- a/src/backend/XpertSphere.MonolithApi.Tests/Utils/FrenchIdentityErrorDescriberTests.cs
+++ b/src/backend/XpertSphere.MonolithApi.Tests/Utils/FrenchIdentityErrorDescriberTests.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using FluentAssertions;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -131,5 +132,33 @@ public class FrenchIdentityErrorDescriberTests
         result.Succeeded.Should().BeFalse();
         result.Errors.Should().ContainSingle(e =>
             e.Description == "Le mot de passe doit contenir au moins un caractère spécial (non alphanumérique).");
+    }
+
+    [Fact]
+    public void AddErrorDescriber_ShouldFlowThroughToPasswordValidator_ViaDependencyInjection()
+    {
+        // PasswordValidator<TUser>.Describer vient de son propre paramètre de constructeur
+        // (optionnel, résolu par le conteneur DI), pas de UserManager.ErrorDescriber (vérifié par
+        // décompilation de Microsoft.Extensions.Identity.Core 9.0.7 : le constructeur fait
+        // `Describer = errors ?? new IdentityErrorDescriber();`). Ce test reproduit donc le
+        // graphe DI réel (même mécanisme que AddIdentity<...>().AddErrorDescriber<...>() dans
+        // SecurityExtensions.AddSecurity) pour prouver que .AddErrorDescriber<FrenchIdentityErrorDescriber>()
+        // atteint bien PasswordValidator via injection, et pas seulement UserManager.
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(new Mock<IUserStore<IdentityUser>>().Object);
+        services.AddIdentityCore<IdentityUser>()
+            .AddErrorDescriber<FrenchIdentityErrorDescriber>();
+
+        using var provider = services.BuildServiceProvider();
+
+        var passwordValidator = provider.GetServices<IPasswordValidator<IdentityUser>>()
+            .OfType<PasswordValidator<IdentityUser>>()
+            .Should().ContainSingle().Subject;
+
+        passwordValidator.Describer.Should().BeOfType<FrenchIdentityErrorDescriber>();
+
+        var userManager = provider.GetRequiredService<UserManager<IdentityUser>>();
+        userManager.ErrorDescriber.Should().BeOfType<FrenchIdentityErrorDescriber>();
     }
 }

--- a/src/backend/XpertSphere.MonolithApi.Tests/Utils/FrenchIdentityErrorDescriberTests.cs
+++ b/src/backend/XpertSphere.MonolithApi.Tests/Utils/FrenchIdentityErrorDescriberTests.cs
@@ -1,0 +1,135 @@
+using System.Reflection;
+using FluentAssertions;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using XpertSphere.MonolithApi.Utils;
+
+namespace XpertSphere.MonolithApi.Tests.Utils;
+
+/// <summary>
+/// Covers .claude/specifications/localize-identity-error-messages.md, critère d'acceptation 1 :
+/// <see cref="FrenchIdentityErrorDescriber"/> surcharge exhaustivement toutes les méthodes
+/// virtuelles publiques exposées par <see cref="IdentityErrorDescriber"/> pour la version du SDK
+/// réellement utilisée par le projet (vérifié par réflexion, pas par une liste figée à l'avance :
+/// une méthode ajoutée/retirée entre versions du SDK est détectée automatiquement par ce test).
+/// </summary>
+public class FrenchIdentityErrorDescriberTests
+{
+    [Fact]
+    public void AllVirtualMethods_ShouldBeOverriddenByFrenchDescriber()
+    {
+        var baseType = typeof(IdentityErrorDescriber);
+        var derivedType = typeof(FrenchIdentityErrorDescriber);
+
+        var virtualMethods = baseType
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .Where(m => m.DeclaringType == baseType && m.IsVirtual)
+            .ToList();
+
+        // Garde-fou : si le SDK change ce nombre, ce test doit être relu (pas juste ajusté à l'aveugle).
+        virtualMethods.Should().HaveCount(22,
+            "la spec a été rédigée sur la base de 22 méthodes virtuelles pour le SDK utilisé (9.0.7) ; " +
+            "un écart signifie que la version du SDK a changé et que la liste doit être revérifiée");
+
+        var notOverridden = virtualMethods
+            .Where(baseMethod =>
+            {
+                var overridden = derivedType.GetMethod(
+                    baseMethod.Name,
+                    BindingFlags.Public | BindingFlags.Instance,
+                    binder: null,
+                    types: baseMethod.GetParameters().Select(p => p.ParameterType).ToArray(),
+                    modifiers: null);
+
+                return overridden is null || overridden.DeclaringType != derivedType;
+            })
+            .Select(m => m.Name)
+            .ToList();
+
+        notOverridden.Should().BeEmpty(
+            "toutes les méthodes virtuelles de IdentityErrorDescriber doivent être surchargées par FrenchIdentityErrorDescriber");
+    }
+
+    [Fact]
+    public void PasswordTooShort_ShouldInterpolateLength()
+    {
+        var describer = new FrenchIdentityErrorDescriber();
+
+        var error = describer.PasswordTooShort(8);
+
+        error.Description.Should().Be("Le mot de passe doit contenir au moins 8 caractères.");
+        error.Code.Should().Be("PasswordTooShort");
+    }
+
+    [Fact]
+    public void PasswordRequiresNonAlphanumeric_ShouldReturnFrenchMessage()
+    {
+        var describer = new FrenchIdentityErrorDescriber();
+
+        var error = describer.PasswordRequiresNonAlphanumeric();
+
+        error.Description.Should().Be("Le mot de passe doit contenir au moins un caractère spécial (non alphanumérique).");
+        error.Code.Should().Be("PasswordRequiresNonAlphanumeric");
+    }
+
+    [Fact]
+    public void InvalidToken_ShouldReturnFrenchMessage()
+    {
+        var describer = new FrenchIdentityErrorDescriber();
+
+        var error = describer.InvalidToken();
+
+        error.Description.Should().Be("Jeton invalide.");
+        error.Code.Should().Be("InvalidToken");
+    }
+
+    [Fact]
+    public void DuplicateEmail_ShouldPreservePlaceholder()
+    {
+        var describer = new FrenchIdentityErrorDescriber();
+
+        var error = describer.DuplicateEmail("test@example.com");
+
+        error.Description.Should().Be("L'email « test@example.com » est déjà utilisé.");
+    }
+
+    [Fact]
+    public async Task PasswordValidator_WithRealDescriber_ShouldReturnFrenchNonAlphanumericMessage()
+    {
+        // Exerce le vrai chemin runtime (PasswordValidator<TUser> d'Identity + le descripteur réel),
+        // pas seulement un IdentityError construit à la main : un mot de passe respectant longueur/
+        // majuscule/minuscule/chiffre mais sans caractère spécial doit produire le message français.
+        var describer = new FrenchIdentityErrorDescriber();
+        var validator = new PasswordValidator<IdentityUser>(describer);
+
+        var options = new IdentityOptions
+        {
+            Password =
+            {
+                RequireDigit = true,
+                RequireLowercase = true,
+                RequireUppercase = true,
+                RequireNonAlphanumeric = true,
+                RequiredLength = 8,
+                RequiredUniqueChars = 1
+            }
+        };
+        var identityOptions = Options.Create(options);
+
+        var store = new Mock<IUserStore<IdentityUser>>();
+        var userManager = new UserManager<IdentityUser>(
+            store.Object, identityOptions, new PasswordHasher<IdentityUser>(),
+            new List<IUserValidator<IdentityUser>>(), new List<IPasswordValidator<IdentityUser>> { validator },
+            new UpperInvariantLookupNormalizer(), describer,
+            new Mock<IServiceProvider>().Object,
+            new Mock<ILogger<UserManager<IdentityUser>>>().Object);
+
+        var result = await validator.ValidateAsync(userManager, new IdentityUser(), "Abcdefg1");
+
+        result.Succeeded.Should().BeFalse();
+        result.Errors.Should().ContainSingle(e =>
+            e.Description == "Le mot de passe doit contenir au moins un caractère spécial (non alphanumérique).");
+    }
+}

--- a/src/backend/XpertSphere.MonolithApi/DTOs/Auth/AccountLinkingDto.cs
+++ b/src/backend/XpertSphere.MonolithApi/DTOs/Auth/AccountLinkingDto.cs
@@ -4,9 +4,12 @@ namespace XpertSphere.MonolithApi.DTOs.Auth;
 
 public record AccountLinkingDto
 {
-    [Required] [EmailAddress] public required string Email { get; init; }
+    [Required(ErrorMessage = "L'email est obligatoire")]
+    [EmailAddress(ErrorMessage = "Format d'email invalide")]
+    public required string Email { get; init; }
 
-    [Required] public required string EntraIdToken { get; init; }
+    [Required(ErrorMessage = "Le jeton Entra ID est obligatoire")]
+    public required string EntraIdToken { get; init; }
 
     public string? ExternalId { get; init; }
 

--- a/src/backend/XpertSphere.MonolithApi/DTOs/Auth/AdminResetPasswordDto.cs
+++ b/src/backend/XpertSphere.MonolithApi/DTOs/Auth/AdminResetPasswordDto.cs
@@ -10,20 +10,20 @@ public class AdminResetPasswordDto
     /// <summary>
     /// Email of the user whose password should be reset
     /// </summary>
-    [Required(ErrorMessage = "Email is required")]
-    [EmailAddress(ErrorMessage = "Invalid email format")]
+    [Required(ErrorMessage = "L'email est obligatoire")]
+    [EmailAddress(ErrorMessage = "Format d'email invalide")]
     public string Email { get; set; } = string.Empty;
 
     /// <summary>
     /// New password for the user
     /// </summary>
-    [Required(ErrorMessage = "New password is required")]
-    [MinLength(6, ErrorMessage = "Password must be at least 6 characters long")]
+    [Required(ErrorMessage = "Le nouveau mot de passe est obligatoire")]
+    [MinLength(6, ErrorMessage = "Le mot de passe doit contenir au moins 6 caractères")]
     public string NewPassword { get; set; } = string.Empty;
 
     /// <summary>
     /// Confirmation of the new password
     /// </summary>
-    [Required(ErrorMessage = "Password confirmation is required")]
+    [Required(ErrorMessage = "La confirmation du mot de passe est obligatoire")]
     public string ConfirmPassword { get; set; } = string.Empty;
 }

--- a/src/backend/XpertSphere.MonolithApi/DTOs/Auth/ChangePasswordDto.cs
+++ b/src/backend/XpertSphere.MonolithApi/DTOs/Auth/ChangePasswordDto.cs
@@ -4,11 +4,14 @@ namespace XpertSphere.MonolithApi.DTOs.Auth;
 
 public record ChangePasswordDto
 {
-    [Required] public required string CurrentPassword { get; init; }
+    [Required(ErrorMessage = "Le mot de passe actuel est obligatoire")]
+    public required string CurrentPassword { get; init; }
 
-    [Required] [MinLength(6)] public required string NewPassword { get; init; }
+    [Required(ErrorMessage = "Le nouveau mot de passe est obligatoire")]
+    [MinLength(6, ErrorMessage = "Le mot de passe doit contenir au moins 6 caractères")]
+    public required string NewPassword { get; init; }
 
-    [Required]
-    [Compare(nameof(NewPassword), ErrorMessage = "Passwords do not match")]
+    [Required(ErrorMessage = "La confirmation du mot de passe est obligatoire")]
+    [Compare(nameof(NewPassword), ErrorMessage = "Les mots de passe ne correspondent pas")]
     public required string ConfirmPassword { get; init; }
 }

--- a/src/backend/XpertSphere.MonolithApi/DTOs/Auth/ConfirmEmailDto.cs
+++ b/src/backend/XpertSphere.MonolithApi/DTOs/Auth/ConfirmEmailDto.cs
@@ -4,7 +4,10 @@ namespace XpertSphere.MonolithApi.DTOs.Auth;
 
 public record ConfirmEmailDto
 {
-    [Required] [EmailAddress] public required string Email { get; init; }
+    [Required(ErrorMessage = "L'email est obligatoire")]
+    [EmailAddress(ErrorMessage = "Format d'email invalide")]
+    public required string Email { get; init; }
 
-    [Required] public required string Token { get; init; }
+    [Required(ErrorMessage = "Le jeton est obligatoire")]
+    public required string Token { get; init; }
 }

--- a/src/backend/XpertSphere.MonolithApi/DTOs/Auth/EntraIdCallbackDto.cs
+++ b/src/backend/XpertSphere.MonolithApi/DTOs/Auth/EntraIdCallbackDto.cs
@@ -4,9 +4,11 @@ namespace XpertSphere.MonolithApi.DTOs.Auth;
 
 public record EntraIdCallbackDto
 {
-    [Required] public required string Code { get; init; }
+    [Required(ErrorMessage = "Le code est obligatoire")]
+    public required string Code { get; init; }
 
-    [Required] public required string State { get; init; }
+    [Required(ErrorMessage = "Le paramètre state est obligatoire")]
+    public required string State { get; init; }
 
     public string? Error { get; init; }
 

--- a/src/backend/XpertSphere.MonolithApi/DTOs/Auth/EntraIdLoginUrlDto.cs
+++ b/src/backend/XpertSphere.MonolithApi/DTOs/Auth/EntraIdLoginUrlDto.cs
@@ -4,7 +4,8 @@ namespace XpertSphere.MonolithApi.DTOs.Auth;
 
 public record EntraIdLoginUrlDto
 {
-    [EmailAddress] public string? Email { get; init; }
+    [EmailAddress(ErrorMessage = "Format d'email invalide")]
+    public string? Email { get; init; }
 
     public string? ReturnUrl { get; init; } = "/dashboard";
 

--- a/src/backend/XpertSphere.MonolithApi/DTOs/Auth/ForgotPasswordDto.cs
+++ b/src/backend/XpertSphere.MonolithApi/DTOs/Auth/ForgotPasswordDto.cs
@@ -4,5 +4,7 @@ namespace XpertSphere.MonolithApi.DTOs.Auth;
 
 public record ForgotPasswordDto
 {
-    [Required] [EmailAddress] public required string Email { get; init; }
+    [Required(ErrorMessage = "L'email est obligatoire")]
+    [EmailAddress(ErrorMessage = "Format d'email invalide")]
+    public required string Email { get; init; }
 }

--- a/src/backend/XpertSphere.MonolithApi/DTOs/Auth/LinkAccountDto.cs
+++ b/src/backend/XpertSphere.MonolithApi/DTOs/Auth/LinkAccountDto.cs
@@ -4,5 +4,6 @@ namespace XpertSphere.MonolithApi.DTOs.Auth;
 
 public record LinkAccountDto
 {
-    [Required] public required string EntraIdToken { get; init; }
+    [Required(ErrorMessage = "Le jeton Entra ID est obligatoire")]
+    public required string EntraIdToken { get; init; }
 }

--- a/src/backend/XpertSphere.MonolithApi/DTOs/Auth/LoginDto.cs
+++ b/src/backend/XpertSphere.MonolithApi/DTOs/Auth/LoginDto.cs
@@ -4,9 +4,13 @@ namespace XpertSphere.MonolithApi.DTOs.Auth;
 
 public record LoginDto
 {
-    [Required] [EmailAddress] public required string Email { get; init; }
+    [Required(ErrorMessage = "L'email est obligatoire")]
+    [EmailAddress(ErrorMessage = "Format d'email invalide")]
+    public required string Email { get; init; }
 
-    [Required] [MinLength(6)] public required string Password { get; init; }
+    [Required(ErrorMessage = "Le mot de passe est obligatoire")]
+    [MinLength(6, ErrorMessage = "Le mot de passe doit contenir au moins 6 caractères")]
+    public required string Password { get; init; }
 
     public bool RememberMe { get; init; } = false;
 

--- a/src/backend/XpertSphere.MonolithApi/DTOs/Auth/RefreshTokenDto.cs
+++ b/src/backend/XpertSphere.MonolithApi/DTOs/Auth/RefreshTokenDto.cs
@@ -4,7 +4,10 @@ namespace XpertSphere.MonolithApi.DTOs.Auth;
 
 public record RefreshTokenDto
 {
-    [Required] [EmailAddress] public required string Email { get; init; }
+    [Required(ErrorMessage = "L'email est obligatoire")]
+    [EmailAddress(ErrorMessage = "Format d'email invalide")]
+    public required string Email { get; init; }
 
-    [Required] public required string RefreshToken { get; init; }
+    [Required(ErrorMessage = "Le jeton de rafraîchissement est obligatoire")]
+    public required string RefreshToken { get; init; }
 }

--- a/src/backend/XpertSphere.MonolithApi/DTOs/Auth/RegisterCandidateDto.cs
+++ b/src/backend/XpertSphere.MonolithApi/DTOs/Auth/RegisterCandidateDto.cs
@@ -7,19 +7,28 @@ namespace XpertSphere.MonolithApi.DTOs.Auth;
 
 public record RegisterCandidateDto
 {
-    [Required] [EmailAddress] public required string Email { get; init; }
+    [Required(ErrorMessage = "L'email est obligatoire")]
+    [EmailAddress(ErrorMessage = "Format d'email invalide")]
+    public required string Email { get; init; }
 
-    [Required] [MinLength(6)] public required string Password { get; init; }
+    [Required(ErrorMessage = "Le mot de passe est obligatoire")]
+    [MinLength(6, ErrorMessage = "Le mot de passe doit contenir au moins 6 caractères")]
+    public required string Password { get; init; }
 
-    [Required]
-    [Compare(nameof(Password), ErrorMessage = "Passwords do not match")]
+    [Required(ErrorMessage = "La confirmation du mot de passe est obligatoire")]
+    [Compare(nameof(Password), ErrorMessage = "Les mots de passe ne correspondent pas")]
     public required string ConfirmPassword { get; init; }
 
-    [Required] [MaxLength(100)] public required string FirstName { get; init; }
+    [Required(ErrorMessage = "Le prénom est obligatoire")]
+    [MaxLength(100, ErrorMessage = "Le prénom ne peut pas dépasser 100 caractères")]
+    public required string FirstName { get; init; }
 
-    [Required] [MaxLength(100)] public required string LastName { get; init; }
+    [Required(ErrorMessage = "Le nom est obligatoire")]
+    [MaxLength(100, ErrorMessage = "Le nom ne peut pas dépasser 100 caractères")]
+    public required string LastName { get; init; }
 
-    [Phone] public string? PhoneNumber { get; init; }
+    [Phone(ErrorMessage = "Format de numéro de téléphone invalide")]
+    public string? PhoneNumber { get; init; }
 
     // Address Information (matching Address model)
     public string? StreetNumber { get; init; }
@@ -49,9 +58,11 @@ public record RegisterCandidateDto
     public string TimeZone { get; init; } = "UTC";
 
     // Legal
-    [Required] public bool AcceptTerms { get; init; } = false;
+    [Required(ErrorMessage = "Vous devez accepter les conditions d'utilisation")]
+    public bool AcceptTerms { get; init; } = false;
 
-    [Required] public bool AcceptPrivacyPolicy { get; init; } = false;
+    [Required(ErrorMessage = "Vous devez accepter la politique de confidentialité")]
+    public bool AcceptPrivacyPolicy { get; init; } = false;
 
     public DateTime? ConsentGivenAt { get; init; }
 

--- a/src/backend/XpertSphere.MonolithApi/DTOs/Auth/RegisterDto.cs
+++ b/src/backend/XpertSphere.MonolithApi/DTOs/Auth/RegisterDto.cs
@@ -5,23 +5,34 @@ namespace XpertSphere.MonolithApi.DTOs.Auth;
 
 public record RegisterDto
 {
-    [Required] [EmailAddress] public required string Email { get; init; }
+    [Required(ErrorMessage = "L'email est obligatoire")]
+    [EmailAddress(ErrorMessage = "Format d'email invalide")]
+    public required string Email { get; init; }
 
-    [Required] [MinLength(6)] public required string Password { get; init; }
+    [Required(ErrorMessage = "Le mot de passe est obligatoire")]
+    [MinLength(6, ErrorMessage = "Le mot de passe doit contenir au moins 6 caractères")]
+    public required string Password { get; init; }
 
-    [Required]
-    [Compare(nameof(Password), ErrorMessage = "Passwords do not match")]
+    [Required(ErrorMessage = "La confirmation du mot de passe est obligatoire")]
+    [Compare(nameof(Password), ErrorMessage = "Les mots de passe ne correspondent pas")]
     public required string ConfirmPassword { get; init; }
 
-    [Required] [MaxLength(100)] public required string FirstName { get; init; }
+    [Required(ErrorMessage = "Le prénom est obligatoire")]
+    [MaxLength(100, ErrorMessage = "Le prénom ne peut pas dépasser 100 caractères")]
+    public required string FirstName { get; init; }
 
-    [Required] [MaxLength(100)] public required string LastName { get; init; }
+    [Required(ErrorMessage = "Le nom est obligatoire")]
+    [MaxLength(100, ErrorMessage = "Le nom ne peut pas dépasser 100 caractères")]
+    public required string LastName { get; init; }
 
-    [Phone] public string? PhoneNumber { get; init; }
+    [Phone(ErrorMessage = "Format de numéro de téléphone invalide")]
+    public string? PhoneNumber { get; init; }
 
-    [Required] public required List<Training>? Trainings { get; init; }
+    [Required(ErrorMessage = "La liste des formations est obligatoire")]
+    public required List<Training>? Trainings { get; init; }
 
-    [Required] public required List<Experience>? Experiences { get; init; }
+    [Required(ErrorMessage = "La liste des expériences est obligatoire")]
+    public required List<Experience>? Experiences { get; init; }
 
     public bool AcceptTerms { get; init; } = false;
 

--- a/src/backend/XpertSphere.MonolithApi/DTOs/Auth/ResendConfirmationDto.cs
+++ b/src/backend/XpertSphere.MonolithApi/DTOs/Auth/ResendConfirmationDto.cs
@@ -4,5 +4,7 @@ namespace XpertSphere.MonolithApi.DTOs.Auth;
 
 public record ResendConfirmationDto
 {
-    [Required] [EmailAddress] public required string Email { get; init; }
+    [Required(ErrorMessage = "L'email est obligatoire")]
+    [EmailAddress(ErrorMessage = "Format d'email invalide")]
+    public required string Email { get; init; }
 }

--- a/src/backend/XpertSphere.MonolithApi/DTOs/Auth/ResetPasswordDto.cs
+++ b/src/backend/XpertSphere.MonolithApi/DTOs/Auth/ResetPasswordDto.cs
@@ -4,13 +4,18 @@ namespace XpertSphere.MonolithApi.DTOs.Auth;
 
 public record ResetPasswordDto
 {
-    [Required] [EmailAddress] public required string Email { get; init; }
+    [Required(ErrorMessage = "L'email est obligatoire")]
+    [EmailAddress(ErrorMessage = "Format d'email invalide")]
+    public required string Email { get; init; }
 
-    [Required] public required string Token { get; init; }
+    [Required(ErrorMessage = "Le jeton est obligatoire")]
+    public required string Token { get; init; }
 
-    [Required] [MinLength(6)] public required string NewPassword { get; init; }
+    [Required(ErrorMessage = "Le mot de passe est obligatoire")]
+    [MinLength(6, ErrorMessage = "Le mot de passe doit contenir au moins 6 caractères")]
+    public required string NewPassword { get; init; }
 
-    [Required]
-    [Compare(nameof(NewPassword), ErrorMessage = "Passwords do not match")]
+    [Required(ErrorMessage = "La confirmation du mot de passe est obligatoire")]
+    [Compare(nameof(NewPassword), ErrorMessage = "Les mots de passe ne correspondent pas")]
     public required string ConfirmPassword { get; init; }
 }

--- a/src/backend/XpertSphere.MonolithApi/DTOs/User/CreateUserDto.cs
+++ b/src/backend/XpertSphere.MonolithApi/DTOs/User/CreateUserDto.cs
@@ -5,28 +5,36 @@ namespace XpertSphere.MonolithApi.DTOs.User;
 
 public class CreateUserDto
 {
-    [Required] [MaxLength(100)] public required string FirstName { get; set; }
+    [Required(ErrorMessage = "Le prénom est obligatoire")]
+    [MaxLength(100, ErrorMessage = "Le prénom ne peut pas dépasser 100 caractères")]
+    public required string FirstName { get; set; }
 
-    [Required] [MaxLength(100)] public required string LastName { get; set; }
+    [Required(ErrorMessage = "Le nom est obligatoire")]
+    [MaxLength(100, ErrorMessage = "Le nom ne peut pas dépasser 100 caractères")]
+    public required string LastName { get; set; }
 
-    [Required]
-    [EmailAddress]
-    [MaxLength(255)]
+    [Required(ErrorMessage = "L'email est obligatoire")]
+    [EmailAddress(ErrorMessage = "Format d'email invalide")]
+    [MaxLength(255, ErrorMessage = "L'email ne peut pas dépasser 255 caractères")]
     public required string Email { get; set; }
 
-    [MaxLength(20)] public string? PhoneNumber { get; set; }
+    [MaxLength(20, ErrorMessage = "Le numéro de téléphone ne peut pas dépasser 20 caractères")]
+    public string? PhoneNumber { get; set; }
 
     // For internal users
     public Guid? OrganizationId { get; set; }
 
-    [MaxLength(50)] public string? EmployeeId { get; set; }
+    [MaxLength(50, ErrorMessage = "Le matricule ne peut pas dépasser 50 caractères")]
+    public string? EmployeeId { get; set; }
 
-    [MaxLength(100)] public string? Department { get; set; }
+    [MaxLength(100, ErrorMessage = "Le département ne peut pas dépasser 100 caractères")]
+    public string? Department { get; set; }
 
     public DateTime? HireDate { get; set; }
 
     // For candidates
-    [MaxLength(255)] public string? LinkedInProfile { get; set; }
+    [MaxLength(255, ErrorMessage = "Le profil LinkedIn ne peut pas dépasser 255 caractères")]
+    public string? LinkedInProfile { get; set; }
 
     public string? Skills { get; set; }
 
@@ -40,21 +48,28 @@ public class CreateUserDto
 
     public DateTime? Availability { get; set; }
 
-    [MaxLength(500)] public string? CvPath { get; set; }
+    [MaxLength(500, ErrorMessage = "Le chemin du CV ne peut pas dépasser 500 caractères")]
+    public string? CvPath { get; set; }
 
     // Communication preferences
     public bool EmailNotificationsEnabled { get; set; } = true;
     public bool SmsNotificationsEnabled { get; set; } = false;
-    [MaxLength(20)] public string? PreferredLanguage { get; set; } = "fr";
-    [MaxLength(50)] public string? TimeZone { get; set; } = "UTC";
+
+    [MaxLength(20, ErrorMessage = "La langue préférée ne peut pas dépasser 20 caractères")]
+    public string? PreferredLanguage { get; set; } = "fr";
+
+    [MaxLength(50, ErrorMessage = "Le fuseau horaire ne peut pas dépasser 50 caractères")]
+    public string? TimeZone { get; set; } = "UTC";
 
     // Consent
     public DateTime? ConsentGivenAt { get; set; }
 
     // Authentication & Security
-    [MaxLength(255)] public string? ExternalId { get; set; }
+    [MaxLength(255, ErrorMessage = "L'identifiant externe ne peut pas dépasser 255 caractères")]
+    public string? ExternalId { get; set; }
 
-    [Required] public string? Password { get; set; }
+    [Required(ErrorMessage = "Le mot de passe est obligatoire")]
+    public string? Password { get; set; }
 
     public bool EmailConfirmed { get; set; } = false;
     public bool IsActive { get; set; } = true;
@@ -65,17 +80,24 @@ public class CreateUserDto
 
 public class AddressDto
 {
-    [MaxLength(10)] public string? StreetNumber { get; set; }
+    [MaxLength(10, ErrorMessage = "Le numéro de rue ne peut pas dépasser 10 caractères")]
+    public string? StreetNumber { get; set; }
 
-    [MaxLength(200)] public string? StreetName { get; set; }
+    [MaxLength(200, ErrorMessage = "Le nom de rue ne peut pas dépasser 200 caractères")]
+    public string? StreetName { get; set; }
 
-    [MaxLength(100)] public string? City { get; set; }
+    [MaxLength(100, ErrorMessage = "La ville ne peut pas dépasser 100 caractères")]
+    public string? City { get; set; }
 
-    [MaxLength(20)] public string? PostalCode { get; set; }
+    [MaxLength(20, ErrorMessage = "Le code postal ne peut pas dépasser 20 caractères")]
+    public string? PostalCode { get; set; }
 
-    [MaxLength(100)] public string? Region { get; set; }
+    [MaxLength(100, ErrorMessage = "La région ne peut pas dépasser 100 caractères")]
+    public string? Region { get; set; }
 
-    [MaxLength(100)] public string? Country { get; set; } = "France";
+    [MaxLength(100, ErrorMessage = "Le pays ne peut pas dépasser 100 caractères")]
+    public string? Country { get; set; } = "France";
 
-    [MaxLength(100)] public string? AddressLine2 { get; set; }
+    [MaxLength(100, ErrorMessage = "Le complément d'adresse ne peut pas dépasser 100 caractères")]
+    public string? AddressLine2 { get; set; }
 }

--- a/src/backend/XpertSphere.MonolithApi/Extensions/DatabaseExtensions.cs
+++ b/src/backend/XpertSphere.MonolithApi/Extensions/DatabaseExtensions.cs
@@ -56,8 +56,21 @@ public static partial class DatabaseExtensions
 
         try
         {
-            // Apply pending migrations
-            await context.Database.MigrateAsync();
+            // Apply pending migrations. Real deployments always use the SQL Server (relational)
+            // provider configured in AddDatabase above, so this branch is unchanged for them.
+            // The EnsureCreatedAsync fallback only exists so that the WebApplicationFactory-based
+            // integration harness (XpertSphere.MonolithApi.Tests/Integration/**) can swap in the
+            // EF Core InMemory provider, which does not support migrations - see
+            // .claude/specifications/localize-identity-error-messages.md, critères d'acceptation
+            // 3/4/5/9.
+            if (context.Database.IsRelational())
+            {
+                await context.Database.MigrateAsync();
+            }
+            else
+            {
+                await context.Database.EnsureCreatedAsync();
+            }
 
             // Seed initial data if needed
             await SeedDatabaseAsync(context, userManager, configuration, app.Environment);

--- a/src/backend/XpertSphere.MonolithApi/Extensions/DatabaseExtensions.cs
+++ b/src/backend/XpertSphere.MonolithApi/Extensions/DatabaseExtensions.cs
@@ -126,6 +126,23 @@ public static partial class DatabaseExtensions
     {
         await SeedXpertSphereOrganizationAsync(context, configuration);
         await SeedDefaultRolesAsync(context);
+
+        // Persist here: SeedPlatformSuperAdminAsync below looks up the XpertSphere organization
+        // and the PlatformSuperAdmin role via LINQ queries (context.Organizations/Roles
+        // .FirstOrDefaultAsync(...)), which do not see entities merely Added-but-not-yet-saved on
+        // the change tracker. Without this intermediate save, on a completely fresh database (the
+        // very first application startup ever) both lookups return null and PlatformSuperAdmin
+        // creation is silently skipped ("XpertSphere organization not found. Cannot create
+        // PlatformSuperAdmin" in the logs) - the app then "self-heals" on its next restart, once
+        // the final SaveChangesAsync of a prior run has actually persisted the organization/roles.
+        // Found while building the WebApplicationFactory-based integration harness for
+        // localize-identity-error-messages.md (critères d'acceptation 3/4/5/9): a fresh
+        // in-memory database exercises exactly this first-run path on every test run. Pre-existing
+        // bug, unrelated to Identity error localization; fixed here as a minimal, backward
+        // compatible change (idempotent on subsequent runs where the organization/roles already
+        // exist).
+        await context.SaveChangesAsync();
+
         await SeedPlatformSuperAdminAsync(context, userManager, configuration);
 
         // Demo dataset (demo organizations/users/job offers/candidates/applications) is only

--- a/src/backend/XpertSphere.MonolithApi/Extensions/SecurityExtensions.cs
+++ b/src/backend/XpertSphere.MonolithApi/Extensions/SecurityExtensions.cs
@@ -27,7 +27,8 @@ public static class SecurityExtensions
                 ConfigureTokenOptions(options);
             })
             .AddEntityFrameworkStores<XpertSphereDbContext>()
-            .AddDefaultTokenProviders();
+            .AddDefaultTokenProviders()
+            .AddErrorDescriber<FrenchIdentityErrorDescriber>();
 
         // Configure Authentication (JWT + Entra ID)
         services.AddMultiModeAuthentication(configuration, environment, useEntraId);

--- a/src/backend/XpertSphere.MonolithApi/Program.cs
+++ b/src/backend/XpertSphere.MonolithApi/Program.cs
@@ -1,6 +1,8 @@
+using System.Globalization;
 using System.Text.Json.Serialization;
 using System.Threading.RateLimiting;
 using DotNetEnv;
+using Microsoft.AspNetCore.Localization;
 using Microsoft.AspNetCore.RateLimiting;
 using XpertSphere.MonolithApi.Config;
 using XpertSphere.MonolithApi.Extensions;
@@ -137,6 +139,17 @@ app.MapHealthChecks("/health");
 // Security Pipeline
 app.UseHttpsRedirection();
 app.UseCookiePolicy();
+
+// Localisation : culture unique fr-FR (formats de date/nombre ; ne traduit pas à elle seule les
+// messages natifs IdentityErrorDescriber, voir Utils/FrenchIdentityErrorDescriber.cs et
+// .claude/specifications/localize-identity-error-messages.md, §6).
+var supportedCultures = new[] { new CultureInfo("fr-FR") };
+app.UseRequestLocalization(new RequestLocalizationOptions
+{
+    DefaultRequestCulture = new RequestCulture("fr-FR"),
+    SupportedCultures = supportedCultures,
+    SupportedUICultures = supportedCultures
+});
 
 // Use CORS only in Development
 if (app.Environment.IsDevelopment())

--- a/src/backend/XpertSphere.MonolithApi/Utils/FrenchIdentityErrorDescriber.cs
+++ b/src/backend/XpertSphere.MonolithApi/Utils/FrenchIdentityErrorDescriber.cs
@@ -1,0 +1,218 @@
+using Microsoft.AspNetCore.Identity;
+
+namespace XpertSphere.MonolithApi.Utils;
+
+/// <summary>
+/// Traduction en français des messages natifs d'ASP.NET Core Identity (<see cref="IdentityErrorDescriber"/>).
+/// ASP.NET Core Identity ne fournit pas de ressources satellites françaises pour ces textes (câblés
+/// en dur en anglais dans le framework) : cette classe surcharge chaque méthode virtuelle de la
+/// classe de base pour renvoyer un texte français en dur, indépendamment de la culture de la requête
+/// (voir .claude/specifications/localize-identity-error-messages.md).
+/// Enregistrée via <c>.AddErrorDescriber&lt;FrenchIdentityErrorDescriber&gt;()</c> dans
+/// <see cref="XpertSphere.MonolithApi.Extensions.SecurityExtensions.AddSecurity"/>.
+/// </summary>
+/// <remarks>
+/// Exhaustivité vérifiée par réflexion contre la version du SDK réellement utilisée (9.0.7) :
+/// 22 méthodes virtuelles publiques déclarées par <see cref="IdentityErrorDescriber"/>, toutes
+/// surchargées ci-dessous (voir <c>FrenchIdentityErrorDescriberTests</c>).
+/// </remarks>
+public class FrenchIdentityErrorDescriber : IdentityErrorDescriber
+{
+    public override IdentityError DefaultError()
+    {
+        return new IdentityError
+        {
+            Code = nameof(DefaultError),
+            Description = "Une erreur inconnue est survenue."
+        };
+    }
+
+    public override IdentityError ConcurrencyFailure()
+    {
+        return new IdentityError
+        {
+            Code = nameof(ConcurrencyFailure),
+            Description = "Échec de concurrence : cet élément a été modifié entre-temps."
+        };
+    }
+
+    public override IdentityError PasswordMismatch()
+    {
+        return new IdentityError
+        {
+            Code = nameof(PasswordMismatch),
+            Description = "Mot de passe incorrect."
+        };
+    }
+
+    public override IdentityError InvalidToken()
+    {
+        return new IdentityError
+        {
+            Code = nameof(InvalidToken),
+            Description = "Jeton invalide."
+        };
+    }
+
+    public override IdentityError LoginAlreadyAssociated()
+    {
+        return new IdentityError
+        {
+            Code = nameof(LoginAlreadyAssociated),
+            Description = "Un utilisateur avec cette connexion existe déjà."
+        };
+    }
+
+    public override IdentityError InvalidUserName(string? userName)
+    {
+        return new IdentityError
+        {
+            Code = nameof(InvalidUserName),
+            Description = $"Le nom d'utilisateur « {userName} » n'est pas valide : il ne peut contenir que des lettres ou des chiffres."
+        };
+    }
+
+    public override IdentityError InvalidEmail(string? email)
+    {
+        return new IdentityError
+        {
+            Code = nameof(InvalidEmail),
+            Description = $"L'email « {email} » n'est pas valide."
+        };
+    }
+
+    public override IdentityError DuplicateUserName(string userName)
+    {
+        return new IdentityError
+        {
+            Code = nameof(DuplicateUserName),
+            Description = $"Le nom d'utilisateur « {userName} » est déjà utilisé."
+        };
+    }
+
+    public override IdentityError DuplicateEmail(string email)
+    {
+        return new IdentityError
+        {
+            Code = nameof(DuplicateEmail),
+            Description = $"L'email « {email} » est déjà utilisé."
+        };
+    }
+
+    public override IdentityError InvalidRoleName(string? role)
+    {
+        return new IdentityError
+        {
+            Code = nameof(InvalidRoleName),
+            Description = $"Le nom de rôle « {role} » n'est pas valide."
+        };
+    }
+
+    public override IdentityError DuplicateRoleName(string role)
+    {
+        return new IdentityError
+        {
+            Code = nameof(DuplicateRoleName),
+            Description = $"Le nom de rôle « {role} » est déjà utilisé."
+        };
+    }
+
+    public override IdentityError UserAlreadyHasPassword()
+    {
+        return new IdentityError
+        {
+            Code = nameof(UserAlreadyHasPassword),
+            Description = "Cet utilisateur possède déjà un mot de passe."
+        };
+    }
+
+    public override IdentityError UserLockoutNotEnabled()
+    {
+        return new IdentityError
+        {
+            Code = nameof(UserLockoutNotEnabled),
+            Description = "Le verrouillage n'est pas activé pour cet utilisateur."
+        };
+    }
+
+    public override IdentityError UserAlreadyInRole(string role)
+    {
+        return new IdentityError
+        {
+            Code = nameof(UserAlreadyInRole),
+            Description = $"L'utilisateur possède déjà le rôle « {role} »."
+        };
+    }
+
+    public override IdentityError UserNotInRole(string role)
+    {
+        return new IdentityError
+        {
+            Code = nameof(UserNotInRole),
+            Description = $"L'utilisateur ne possède pas le rôle « {role} »."
+        };
+    }
+
+    public override IdentityError PasswordTooShort(int length)
+    {
+        return new IdentityError
+        {
+            Code = nameof(PasswordTooShort),
+            Description = $"Le mot de passe doit contenir au moins {length} caractères."
+        };
+    }
+
+    public override IdentityError PasswordRequiresUniqueChars(int uniqueChars)
+    {
+        return new IdentityError
+        {
+            Code = nameof(PasswordRequiresUniqueChars),
+            Description = $"Le mot de passe doit contenir au moins {uniqueChars} caractère(s) distinct(s)."
+        };
+    }
+
+    public override IdentityError PasswordRequiresNonAlphanumeric()
+    {
+        return new IdentityError
+        {
+            Code = nameof(PasswordRequiresNonAlphanumeric),
+            Description = "Le mot de passe doit contenir au moins un caractère spécial (non alphanumérique)."
+        };
+    }
+
+    public override IdentityError PasswordRequiresDigit()
+    {
+        return new IdentityError
+        {
+            Code = nameof(PasswordRequiresDigit),
+            Description = "Le mot de passe doit contenir au moins un chiffre (0-9)."
+        };
+    }
+
+    public override IdentityError PasswordRequiresLower()
+    {
+        return new IdentityError
+        {
+            Code = nameof(PasswordRequiresLower),
+            Description = "Le mot de passe doit contenir au moins une lettre minuscule (a-z)."
+        };
+    }
+
+    public override IdentityError PasswordRequiresUpper()
+    {
+        return new IdentityError
+        {
+            Code = nameof(PasswordRequiresUpper),
+            Description = "Le mot de passe doit contenir au moins une lettre majuscule (A-Z)."
+        };
+    }
+
+    public override IdentityError RecoveryCodeRedemptionFailed()
+    {
+        return new IdentityError
+        {
+            Code = nameof(RecoveryCodeRedemptionFailed),
+            Description = "Échec de l'utilisation du code de récupération."
+        };
+    }
+}

--- a/src/frontend/packages/candidate-app/src/components/register/MultiStepRegisterForm.vue
+++ b/src/frontend/packages/candidate-app/src/components/register/MultiStepRegisterForm.vue
@@ -581,10 +581,11 @@ const formData = reactive<RegisterCandidateDto>({
 // Validation rules
 const passwordRules = [
   (val: string) => !!val || 'Mot de passe requis',
-  (val: string) => val.length >= 6 || 'Au moins 6 caractères',
+  (val: string) => val.length >= 8 || 'Au moins 8 caractères',
   (val: string) => /[A-Z]/.test(val) || 'Au moins une majuscule',
   (val: string) => /[a-z]/.test(val) || 'Au moins une minuscule',
   (val: string) => /[0-9]/.test(val) || 'Au moins un chiffre',
+  (val: string) => /[^a-zA-Z0-9]/.test(val) || 'Au moins un caractère spécial',
 ];
 
 const validateEmail = (email: string) => {

--- a/src/frontend/packages/recruiter-app/src/composables/passwordRules.ts
+++ b/src/frontend/packages/recruiter-app/src/composables/passwordRules.ts
@@ -1,0 +1,34 @@
+/**
+ * Règles de complexité de mot de passe alignées sur la politique réelle du backend
+ * (`ConfigurePasswordOptions`, `SecurityExtensions.cs`, `XpertSphere.MonolithApi`) : au moins une
+ * majuscule, une minuscule, un chiffre, un caractère non alphanumérique, longueur minimale 8.
+ *
+ * Longueur minimale fixée à 8 dans tous les cas (même si le backend accepte 6 en Development) :
+ * ce package est un bundle statique qui ne connaît pas l'environnement du backend auquel il parle,
+ * et 8 caractères satisfait toujours l'exigence de longueur du backend, quel que soit
+ * l'environnement cible.
+ *
+ * Factorisé ici pour être partagé entre les 3 emplacements actifs de création/modification de mot
+ * de passe de ce package (`UsersPage.vue` création et dialog « Reset Password », `ProfilePage.vue`
+ * changement de mot de passe) et éviter toute divergence future entre 3 copies indépendantes.
+ *
+ * Limite connue et acceptée (voir
+ * `src/backend/XpertSphere.MonolithApi/.claude/specifications/localize-identity-error-messages.md`,
+ * section « Coordination frontend ») : la regex `/[^a-zA-Z0-9]/` traite une lettre accentuée (ex.
+ * "é") comme un caractère spécial, alors que le backend (`char.IsLetterOrDigit`, Unicode) la
+ * considère alphanumérique et ne validerait donc pas l'exigence `RequireNonAlphanumeric` pour un
+ * mot de passe qui ne contiendrait qu'un tel caractère comme seul symbole non-ASCII. Cas limite
+ * volontairement non traité (complexité disproportionnée pour reproduire `char.IsLetterOrDigit`
+ * côté client).
+ */
+export type PasswordRule = (val: string) => boolean | string;
+
+export function usePasswordComplexityRules(): PasswordRule[] {
+  return [
+    (val: string) => val.length >= 8 || 'Minimum 8 caractères',
+    (val: string) => /[A-Z]/.test(val) || 'Au moins une majuscule',
+    (val: string) => /[a-z]/.test(val) || 'Au moins une minuscule',
+    (val: string) => /[0-9]/.test(val) || 'Au moins un chiffre',
+    (val: string) => /[^a-zA-Z0-9]/.test(val) || 'Au moins un caractère spécial',
+  ];
+}

--- a/src/frontend/packages/recruiter-app/src/pages/ProfilePage.vue
+++ b/src/frontend/packages/recruiter-app/src/pages/ProfilePage.vue
@@ -319,8 +319,7 @@
                   outlined
                   :rules="[
                     (val) => !!val || 'Le nouveau mot de passe est requis',
-                    (val) =>
-                      val.length >= 8 || 'Le mot de passe doit contenir au moins 8 caractères',
+                    ...passwordComplexityRules,
                   ]"
                 />
 
@@ -498,11 +497,13 @@ import { settings } from 'src/settings';
 import { authService } from '../services/authService';
 import type { ChangePasswordDto } from '../models/auth';
 import type { UpdateUserDto } from '../models/user';
+import { usePasswordComplexityRules } from 'src/composables/passwordRules';
 
 const $q = useQuasar();
 const router = useRouter();
 const authStore = useAuthStore();
 const userStore = useUserStore();
+const passwordComplexityRules = usePasswordComplexityRules();
 
 const loading = ref(false);
 const loadingPassword = ref(false);

--- a/src/frontend/packages/recruiter-app/src/pages/admin/UsersPage.vue
+++ b/src/frontend/packages/recruiter-app/src/pages/admin/UsersPage.vue
@@ -275,10 +275,7 @@
               label="Mot de passe *"
               type="password"
               outlined
-              :rules="[
-                (val) => !!val || 'Le mot de passe est requis',
-                (val) => val.length >= 8 || 'Minimum 8 caractères',
-              ]"
+              :rules="[(val) => !!val || 'Le mot de passe est requis', ...passwordComplexityRules]"
             />
 
             <q-toggle
@@ -428,10 +425,7 @@
               label="Nouveau mot de passe *"
               type="password"
               outlined
-              :rules="[
-                (val) => !!val || 'Le mot de passe est requis',
-                (val) => val.length >= 8 || 'Minimum 8 caractères',
-              ]"
+              :rules="[(val) => !!val || 'Le mot de passe est requis', ...passwordComplexityRules]"
             />
 
             <q-input
@@ -483,6 +477,7 @@ import { authService } from '../../services/authService';
 import { useDataTable } from 'src/composables/datatable';
 import { useNotification } from 'src/composables/notification';
 import { useDialog } from 'src/composables/dialog';
+import { usePasswordComplexityRules } from 'src/composables/passwordRules';
 
 const userStore = useUserStore();
 const userRoleStore = useUserRoleStore();
@@ -492,6 +487,7 @@ const authStore = useAuthStore();
 const dataTable = useDataTable();
 const notification = useNotification();
 const dialog = useDialog();
+const passwordComplexityRules = usePasswordComplexityRules();
 
 const showCreateDialog = ref(false);
 const showUserRolesDialog = ref(false);


### PR DESCRIPTION
## Summary
- New `FrenchIdentityErrorDescriber` overriding all 22 `IdentityErrorDescriber` methods (count verified by reflection against the actual installed SDK, 9.0.7), registered via `.AddErrorDescriber<FrenchIdentityErrorDescriber>()`.
- `UseRequestLocalization` with `fr-FR` as the sole supported culture in `Program.cs`.
- French `ErrorMessage` added to every validation attribute across 14 Auth DTOs + `CreateUserDto`/`AddressDto` (verified by exhaustive grep — no attribute left without one).
- Frontend (in scope per the spec's explicit "Coordination frontend" section, confirmed against both `candidate-app`/`recruiter-app` CLAUDE.md already referencing this spec): password rules aligned with the real backend policy (special character rule, min length 8) — `candidate-app`'s `MultiStepRegisterForm.vue`, and a new shared `recruiter-app/src/composables/passwordRules.ts` used by `UsersPage.vue` and `ProfilePage.vue`.

Spec: `src/backend/XpertSphere.MonolithApi/.claude/specifications/localize-identity-error-messages.md`

## Test plan
- [x] 196/196 tests pass (183 MonolithApi + 13 CommunicationService), including a new reflection-based exhaustiveness test and a DI-wiring test proving `PasswordValidator<TUser>`'s own `Describer` (distinct from `UserManager.ErrorDescriber`) actually resolves to the French descriptor through the real `AddIdentityCore` graph.
- [x] `npm run lint` clean on `candidate-app`/`recruiter-app`.
- [ ] Manual (no `WebApplicationFactory` in this test project to verify end-to-end): trigger a real Identity error (e.g. weak password, duplicate email) via Swagger/UI and confirm the HTTP response body is in French.

## Notes (found, not fixed — out of scope)
- `[Required]` on a non-nullable `bool` (`RegisterCandidateDto.AcceptTerms`/`AcceptPrivacyPolicy`) is a no-op — the French message is now correct but will never actually trigger in practice.
- Pre-existing, already documented by the spec: `ProfilePage.vue` posts a `ChangePasswordDto` to `/reset-password`, which expects a `ResetPasswordDto`; `userStore.createUser` only surfaces a generic message, not per-field validation detail.