### PR TITLE
fix(recruiter-app): pre-demo UX polish (6 independent low-risk fixes)

### DIFF
--- a/src/frontend/packages/recruiter-app/src/components/AppNavigation.vue
+++ b/src/frontend/packages/recruiter-app/src/components/AppNavigation.vue
@@ -139,14 +139,12 @@ const filteredAdminItems = computed(() => {
   return [];
 });
 
+// Tableau de bord, Entretiens et Rapports sont volontairement retirés du menu :
+// ce sont de simples pages d'attente ("bientôt disponible"), voir
+// ux-polish-pre-demo.md point 3. Leurs routes restent enregistrées
+// (accès direct par URL toujours possible), seul le point d'entrée depuis
+// le menu disparaît.
 const navigationItems = [
-  {
-    name: 'dashboard',
-    title: 'Tableau de bord',
-    icon: 'dashboard',
-    route: '/',
-    description: 'Voir la vue d’ensemble et les statistiques du recrutement',
-  },
   {
     name: 'jobs',
     title: 'Offres d’emploi',
@@ -167,20 +165,6 @@ const navigationItems = [
     icon: 'assignment',
     route: '/applications',
     description: 'Examiner et traiter les candidatures',
-  },
-  {
-    name: 'interviews',
-    title: 'Entretiens',
-    icon: 'event',
-    route: '/interviews',
-    description: 'Planifier et gérer les entretiens',
-  },
-  {
-    name: 'reports',
-    title: 'Rapports',
-    icon: 'analytics',
-    route: '/reports',
-    description: 'Voir les analyses et rapports de recrutement',
   },
 ];
 

--- a/src/frontend/packages/recruiter-app/src/components/candidates/CvPreviewDialog.vue
+++ b/src/frontend/packages/recruiter-app/src/components/candidates/CvPreviewDialog.vue
@@ -50,7 +50,7 @@ interface Props {
   modelValue: boolean;
   candidateId: string;
   candidateName: string;
-  cvUrl?: string;
+  cvUrl?: string | undefined;
 }
 
 const props = defineProps<Props>();

--- a/src/frontend/packages/recruiter-app/src/components/jobs/JobFilters.vue
+++ b/src/frontend/packages/recruiter-app/src/components/jobs/JobFilters.vue
@@ -247,6 +247,11 @@ function clearAllFilters() {
   delete localFilters.value.workMode;
   delete localFilters.value.contractType;
   delete localFilters.value.status;
+  // Emission explicite et synchrone : le watcher deep sur localFilters (flush "pre")
+  // ne propagerait update:filters qu'après ce tick, donc après le "clear" ci-dessous.
+  // Le parent (JobsPage.vue) lancerait alors sa recherche avec des filtres pas encore
+  // à jour (workMode/contractType/status). On force la mise à jour du parent avant.
+  emit('update:filters', { ...localFilters.value });
   emit('clear');
   void nextTick(() => {
     suppressFieldWatchers = false;

--- a/src/frontend/packages/recruiter-app/src/components/jobs/JobFilters.vue
+++ b/src/frontend/packages/recruiter-app/src/components/jobs/JobFilters.vue
@@ -10,7 +10,7 @@
             clearable
             aria-label="Rechercher parmi les offres d'emploi"
             class="search-input"
-            @keydown.enter="emitSearch"
+            @keydown.enter="handleSearchFieldEnter"
           >
             <template #prepend>
               <q-icon name="search" color="grey-7" />
@@ -37,7 +37,7 @@
             clearable
             aria-label="Filtrer par localisation"
             class="filter-input"
-            @keydown.enter="emitSearch"
+            @keydown.enter="handleSearchFieldEnter"
           >
             <template #prepend>
               <q-icon name="place" size="sm" color="grey-7" />
@@ -123,7 +123,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch, nextTick } from 'vue';
+import { ref, watch, nextTick, onBeforeUnmount } from 'vue';
 import type { JobOfferFilter } from '../../models/job';
 import { WorkMode, ContractType } from '../../enums';
 import { JobOfferStatus, getJobOfferStatusName } from '../../enums';
@@ -170,18 +170,65 @@ watch(
   { deep: true },
 );
 
-watch(
-  () => localFilters.value.title,
-  async (newTitle) => {
-    if (newTitle && newTitle.length >= 3) {
-      await nextTick();
-      emitSearch();
-    } else if (!newTitle || newTitle.length === 0) {
-      await nextTick();
-      emitSearch();
-    }
-  },
-);
+// Debounce local (400ms) partagé par les champs "Titre" et "Localisation" :
+// aucune dépendance de debounce n'est disponible dans ce package pour un
+// q-input texte libre (voir spec ux-polish-pre-demo.md, point 2).
+const SEARCH_DEBOUNCE_MS = 400;
+const SEARCH_MIN_LENGTH = 3;
+let searchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+// Le clic sur "Effacer tous les filtres" vide title/location directement (au lieu
+// de passer par une saisie utilisateur) : sans ce garde, les watchers ci-dessous
+// déclencheraient chacun leur propre recherche immédiate, en plus de celle déjà
+// émise par clearAllFilters (double/triple appel réseau redondant).
+let suppressFieldWatchers = false;
+
+function clearSearchDebounce() {
+  if (searchDebounceTimer) {
+    clearTimeout(searchDebounceTimer);
+    searchDebounceTimer = null;
+  }
+}
+
+async function triggerImmediateSearch() {
+  clearSearchDebounce();
+  await nextTick();
+  emitSearch();
+}
+
+function scheduleDebouncedSearch() {
+  clearSearchDebounce();
+  searchDebounceTimer = setTimeout(() => {
+    searchDebounceTimer = null;
+    emitSearch();
+  }, SEARCH_DEBOUNCE_MS);
+}
+
+function handleSearchFieldChange(newValue: string | null | undefined) {
+  if (suppressFieldWatchers) return;
+
+  const length = newValue?.length ?? 0;
+  if (length === 0) {
+    void triggerImmediateSearch();
+  } else if (length >= SEARCH_MIN_LENGTH) {
+    scheduleDebouncedSearch();
+  } else {
+    // 1 ou 2 caractères : pas de recherche automatique, on annule un
+    // debounce précédemment programmé pour ne pas déclencher un appel
+    // réseau avec une valeur désormais obsolète.
+    clearSearchDebounce();
+  }
+}
+
+function handleSearchFieldEnter() {
+  void triggerImmediateSearch();
+}
+
+watch(() => localFilters.value.title, handleSearchFieldChange);
+watch(() => localFilters.value.location, handleSearchFieldChange);
+
+onBeforeUnmount(() => {
+  clearSearchDebounce();
+});
 
 function emitSearch() {
   emit('search');
@@ -193,12 +240,17 @@ async function handleFilterChange() {
 }
 
 function clearAllFilters() {
+  suppressFieldWatchers = true;
+  clearSearchDebounce();
   localFilters.value.title = '';
   localFilters.value.location = '';
   delete localFilters.value.workMode;
   delete localFilters.value.contractType;
   delete localFilters.value.status;
   emit('clear');
+  void nextTick(() => {
+    suppressFieldWatchers = false;
+  });
 }
 </script>
 

--- a/src/frontend/packages/recruiter-app/src/pages/admin/UsersPage.vue
+++ b/src/frontend/packages/recruiter-app/src/pages/admin/UsersPage.vue
@@ -862,7 +862,7 @@ const assignRole = async () => {
     assignData.expiresAt = assignRoleForm.expiresAt;
   } else {
     const nextYear = new Date();
-    nextYear.setFullYear(nextYear.getFullYear() + 5);
+    nextYear.setFullYear(nextYear.getFullYear() + 1);
     assignData.expiresAt = nextYear.toISOString().split('T')[0]!;
   }
 

--- a/src/frontend/packages/recruiter-app/src/pages/applications/ApplicationDetailPage.vue
+++ b/src/frontend/packages/recruiter-app/src/pages/applications/ApplicationDetailPage.vue
@@ -461,7 +461,6 @@ const goBack = () => {
 };
 
 const viewCandidate = () => {
-  console.log('', application.value);
   if (application.value) {
     router.push(`/candidates/${application.value.candidateId}`);
   }

--- a/src/frontend/packages/recruiter-app/src/pages/applications/ApplicationsPage.vue
+++ b/src/frontend/packages/recruiter-app/src/pages/applications/ApplicationsPage.vue
@@ -66,6 +66,17 @@
           <q-btn flat icon="refresh" :loading="applicationStore.isLoading" @click="refreshData" />
         </div>
 
+        <q-banner v-if="applicationStore.hasError" class="bg-negative text-white q-mb-md">
+          <template #avatar>
+            <q-icon name="error" />
+          </template>
+          {{ applicationStore.errorMessage }}
+          <template #action>
+            <q-btn flat label="Réessayer" @click="refreshData" />
+            <q-btn flat icon="close" @click="applicationStore.clearError" />
+          </template>
+        </q-banner>
+
         <q-table
           v-model:pagination="pagination"
           :rows="applications"

--- a/src/frontend/packages/recruiter-app/src/pages/candidates/CandidatesPage.vue
+++ b/src/frontend/packages/recruiter-app/src/pages/candidates/CandidatesPage.vue
@@ -120,18 +120,6 @@
             </q-td>
           </template>
         </q-table>
-
-        <!-- Pagination -->
-        <div v-if="userStore.totalPages > 1" class="row justify-center q-mt-md">
-          <q-pagination
-            v-model="pagination.page"
-            :max="userStore.totalPages || 1"
-            :max-pages="6"
-            direction-links
-            :boundary-numbers="false"
-            @update:model-value="onPageChange"
-          />
-        </div>
       </q-card-section>
     </q-card>
   </q-page>
@@ -296,11 +284,6 @@ function onSearch() {
 }
 
 function refreshData() {
-  loadCandidates();
-}
-
-function onPageChange(newPage: number) {
-  pagination.value.page = newPage;
   loadCandidates();
 }
 

--- a/src/frontend/packages/recruiter-app/src/router/routes.ts
+++ b/src/frontend/packages/recruiter-app/src/router/routes.ts
@@ -33,9 +33,7 @@ const routes: RouteRecordRaw[] = [
     children: [
       {
         path: '',
-        component: () => import('pages/DashboardPage.vue'),
-        meta: { title: 'Tableau de bord' },
-        beforeEnter: organizationRoleGuard,
+        redirect: '/jobs',
       },
       {
         path: 'jobs',


### PR DESCRIPTION
## Summary
Six independent, low-risk UX fixes bundled together (each too small to warrant its own PR):
1. `ApplicationsPage.vue`: adds the missing error banner (pattern copied from `JobsPage.vue`).
2. `JobFilters.vue`: harmonizes search behavior across Title/Location fields (shared 400ms debounce, 3-char threshold, immediate clear, Enter bypasses debounce).
3. Hides "coming soon" menu items (Dashboard, Interviews, Reports) from `AppNavigation.vue`; root route `/` now redirects to `/jobs` (covers the logo click).
4. `CandidatesPage.vue`: removes the redundant client-side `q-pagination`, keeping only the server-side `q-table` pagination.
5. Removes a stray `console.log` in `ApplicationDetailPage.vue`.
6. `UsersPage.vue`: aligns the role-expiry fallback value to +1 year (was inconsistent between two call sites).

Spec: `src/frontend/packages/recruiter-app/.claude/specifications/ux-polish-pre-demo.md`

## Test plan
- [x] `npm run lint` / `vue-tsc --noEmit` clean (one pre-existing, unrelated error confirmed on `develop`)
- [ ] Manual: error banner shows on `/applications` when the API call fails; search behaves consistently on `/jobs`; sidebar only shows Offres/Candidats/Candidatures; `/` redirects to `/jobs`; `/candidates` has a single pagination control; no stray console log on an application's detail page

## Note
Minor deviation flagged by the developer: `clearAllFilters()` in `JobFilters.vue` now guards against emitting a redundant `clear` events per field cleared (was 2 network calls beyond the necessary one, now 1) — same observable UX, fewer redundant network calls. Not a literal reading of one acceptance criterion but consistent with the point's intent.